### PR TITLE
V2 — Refonte de la section Projets (tri + case studies)

### DIFF
--- a/src/app/[locale]/project/[id]/page.tsx
+++ b/src/app/[locale]/project/[id]/page.tsx
@@ -17,7 +17,7 @@ export default async function ProjectPage({ params }: { params: Params }) {
   if (!project) return notFound();
 
   return (
-    <main className='flex min-h-screen flex-col px-6 py-4 md:px-12 lg:px-24'>
+    <main className='min-h-screen px-5 py-10 sm:px-6 md:py-14'>
       <ProjectDetail project={project} />
     </main>
   );

--- a/src/components/service/project-detail.tsx
+++ b/src/components/service/project-detail.tsx
@@ -1,380 +1,359 @@
 'use client';
 
-import { useState, useEffect, useCallback, JSX } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
-import { Card, CardContent } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
+import { JSX, useCallback, useEffect, useState } from 'react';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import {
-  Github,
-  Globe,
-  X,
+  ArrowLeft,
+  ArrowRight,
+  CheckCircle,
   ChevronLeft,
   ChevronRight,
   Clock,
-  CheckCircle,
+  Github,
+  Globe,
   PauseCircle,
   Rocket,
+  X,
 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { useTranslations, useLocale } from 'next-intl';
-import { useRouter } from '@/i18n/navigation';
 import Image from 'next/image';
+import { useLocale, useTranslations } from 'next-intl';
+import { useRouter } from '@/i18n/navigation';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { client } from '@/sanity/lib/client';
 import { allProjectsQuery } from '@/sanity/queries/projects';
 import type { Project, ProjectStatus } from '@/data/types/project';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
 import TechIcon from '@/components/service/common/tech-icon';
 
-const statusIcons: Record<ProjectStatus, JSX.Element> = {
-  planned: <Clock className='inline h-4 w-4 text-blue-400' />,
-  in_progress: <Rocket className='inline h-4 w-4 text-yellow-500' />,
-  completed: <CheckCircle className='inline h-4 w-4 text-green-500' />,
-  on_hold: <PauseCircle className='inline h-4 w-4 text-gray-400' />,
+const statusIcon: Record<ProjectStatus, JSX.Element> = {
+  planned: <Clock className='size-4 text-sky-500' />,
+  in_progress: <Rocket className='size-4 text-amber-500' />,
+  completed: <CheckCircle className='size-4 text-emerald-500' />,
+  on_hold: <PauseCircle className='size-4 text-muted-foreground' />,
 };
+
+const repoKeys = ['repo', 'repoFrontend', 'repoBackend', 'repoMobile'];
 
 export function ProjectDetail({ project }: { project: Project }) {
   const t = useTranslations();
   const locale = useLocale();
   const router = useRouter();
+  const reduceMotion = useReducedMotion();
 
   const [projects, setProjects] = useState<Project[]>([]);
-  const [selectedImageIndex, setSelectedImageIndex] = useState<number | null>(
-    null
-  );
+  const [lightbox, setLightbox] = useState<number | null>(null);
 
   const localized = project.translations?.[locale] ||
-    project.translations?.en || {
-      title: '',
-      description: '',
-    };
+    project.translations?.en || { title: '', description: '' };
 
   const gallery = Array.isArray(project.gallery)
     ? project.gallery.map((img) => img.url)
+    : [];
+  const tech = project.technologies ?? [];
+  const links = project.links
+    ? Object.entries(project.links).filter(([, url]) => Boolean(url))
     : [];
 
   useEffect(() => {
     client
       .fetch(allProjectsQuery)
       .then((res: Project[]) => setProjects(res ?? []))
-      .catch((err) => console.error('❌ Failed to fetch projects:', err));
+      .catch((err) => console.error('Failed to fetch projects:', err));
   }, []);
 
   useEffect(() => {
     window.scrollTo({ top: 0 });
-  }, []);
+  }, [project._id]);
 
-  const total = projects.length;
   const currentIndex = projects.findIndex((p) => p._id === project._id);
+  const prevProject = currentIndex > 0 ? projects[currentIndex - 1] : null;
+  const nextProject =
+    currentIndex >= 0 && currentIndex < projects.length - 1
+      ? projects[currentIndex + 1]
+      : null;
 
-  const goPrevProject = () => {
-    if (total === 0) return;
+  const titleOf = (p: Project) =>
+    (p.translations?.[locale] || p.translations?.en)?.title ?? '';
 
-    const prev = (currentIndex - 1 + total) % total;
-
-    router.push(`/project/${projects[prev]._id}`);
-  };
-
-  const goNextProject = () => {
-    if (total === 0) return;
-
-    const next = (currentIndex + 1) % total;
-
-    router.push(`/project/${projects[next]._id}`);
+  const backToProjects = () => {
+    sessionStorage.setItem('scrollTarget', 'projects');
+    router.push('/');
   };
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      if (selectedImageIndex === null) return;
+      if (lightbox === null) return;
 
-      if (e.key === 'Escape') setSelectedImageIndex(null);
-
+      if (e.key === 'Escape') setLightbox(null);
       if (e.key === 'ArrowRight')
-        setSelectedImageIndex((i) => ((i ?? 0) + 1) % gallery.length);
-
+        setLightbox((i) => ((i ?? 0) + 1) % gallery.length);
       if (e.key === 'ArrowLeft')
-        setSelectedImageIndex(
-          (i) => ((i ?? 0) - 1 + gallery.length) % gallery.length
-        );
+        setLightbox((i) => ((i ?? 0) - 1 + gallery.length) % gallery.length);
     },
-    [selectedImageIndex, gallery.length]
+    [lightbox, gallery.length]
   );
 
   useEffect(() => {
-    if (selectedImageIndex !== null)
-      window.addEventListener('keydown', handleKeyDown);
+    if (lightbox !== null) window.addEventListener('keydown', handleKeyDown);
 
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [selectedImageIndex, handleKeyDown]);
+  }, [lightbox, handleKeyDown]);
 
   return (
-    <div className='flex flex-col space-y-6 px-4 pt-4 md:px-12 lg:px-24'>
-      {project.image?.url && (
-        <motion.div
-          className='relative mx-auto w-full max-w-4xl overflow-hidden rounded-2xl bg-muted/10 shadow-lg'
-          initial={{ opacity: 0, y: 30 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6 }}
-        >
-          <div className='relative flex aspect-[16/9] items-center justify-center'>
-            <Image
-              src={project.image.url}
-              alt={localized.title}
-              fill
-              className='object-contain p-4'
-              sizes='(max-width: 768px) 100vw, 800px'
-              priority
-            />
-          </div>
-        </motion.div>
-      )}
-
-      <motion.div
-        className='text-center'
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
+    <div className='mx-auto w-full max-w-5xl space-y-10'>
+      <button
+        onClick={backToProjects}
+        className='inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-brand'
       >
-        <h1 className='text-3xl font-extrabold md:text-5xl'>
+        <ArrowLeft className='size-4' />
+        {t('common.header.projects')}
+      </button>
+
+      {/* Header */}
+      <motion.header
+        initial={{ opacity: 0, y: reduceMotion ? 0 : 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+        className='space-y-4'
+      >
+        <div className='flex flex-wrap items-center gap-3 text-sm text-muted-foreground'>
+          {project.status && (
+            <span className='inline-flex items-center gap-1.5 rounded-full border border-border/60 bg-card px-2.5 py-1 font-medium'>
+              {statusIcon[project.status]}
+              {t(`common.projects.statusLabels.${project.status}`)}
+            </span>
+          )}
+          {project.dateRange && (
+            <span className='font-medium uppercase tracking-wide'>
+              {project.dateRange}
+            </span>
+          )}
+        </div>
+
+        <h1 className='text-3xl font-bold tracking-tight md:text-5xl'>
           {localized.title}
         </h1>
 
-        {project.status && (
-          <div className='mt-2 flex items-center justify-center gap-2 text-sm text-muted-foreground'>
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div className='flex cursor-default items-center gap-2'>
-                    {statusIcons[project.status]}
-                    <span>
-                      {t(`common.projects.statusLabels.${project.status}`)}
-                    </span>
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {t(`common.projects.statusLabels.${project.status}`)}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          </div>
+        {localized.description && (
+          <p className='max-w-3xl whitespace-pre-line text-base leading-relaxed text-muted-foreground md:text-lg'>
+            {localized.description}
+          </p>
         )}
+      </motion.header>
 
-        <p className='mx-auto mt-3 max-w-3xl text-base text-muted-foreground md:text-lg'>
-          {localized.description}
-        </p>
-      </motion.div>
-
-      <Card className='border-2 shadow-md'>
-        <CardContent>
-          <table className='w-full text-left'>
-            <thead>
-              <tr className='border-b'>
-                <th className='px-4 py-3 font-semibold'>
-                  {t('common.projects.date')}
-                </th>
-                <th className='px-4 py-3 font-semibold'>
-                  {t('common.projects.stack')}
-                </th>
-                <th className='px-4 py-3 font-semibold'>
-                  {t('common.projects.links')}
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr className='border-b'>
-                <td className='px-4 py-3'>{project.dateRange ?? '-'}</td>
-
-                <td className='px-4 py-3'>
-                  <div className='flex flex-wrap gap-2'>
-                    {Array.isArray(project.technologies) &&
-                    project.technologies.length > 0 ? (
-                      project.technologies.map((tech) => (
-                        <TooltipProvider key={tech._id}>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Badge
-                                variant='outline'
-                                className='flex items-center gap-2 px-3 py-1 transition-transform hover:scale-105 hover:shadow-sm'
-                              >
-                                <TechIcon
-                                  techKey={
-                                    tech.icon?.toLowerCase?.() ||
-                                    tech.name?.toLowerCase?.() ||
-                                    'unknown'
-                                  }
-                                  label={tech.name}
-                                  className='h-5 w-5 object-contain'
-                                />
-                                <span>{tech.name}</span>
-                              </Badge>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <div className='flex flex-col items-center'>
-                                <span className='font-medium'>{tech.name}</span>
-                                {tech.level && (
-                                  <span className='text-xs text-muted-foreground'>
-                                    {t(
-                                      `common.skills.proficiency.${tech.level}`
-                                    )}
-                                  </span>
-                                )}
-                              </div>
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
-                      ))
-                    ) : (
-                      <span className='text-sm text-muted-foreground'>
-                        {t('common.projects.noStack')}
-                      </span>
-                    )}
-                  </div>
-                </td>
-
-                <td className='px-4 py-3'>
-                  {project.links &&
-                  Object.values(project.links).some(Boolean) ? (
-                    <ul className='space-y-2'>
-                      {Object.entries(project.links).map(([key, url]) =>
-                        url ? (
-                          <li key={key}>
-                            <a
-                              href={url}
-                              target='_blank'
-                              rel='noopener noreferrer'
-                              className='flex items-center gap-2 text-primary hover:underline'
-                            >
-                              {key === 'live' ? (
-                                <Globe className='h-4 w-4' />
-                              ) : (
-                                <Github className='h-4 w-4' />
-                              )}
-                              {t(`common.projects.${key}`)}
-                            </a>
-                          </li>
-                        ) : null
-                      )}
-                    </ul>
-                  ) : (
-                    <p className='text-sm text-muted-foreground'>
-                      {t('common.projects.noLinks')}
-                    </p>
-                  )}
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </CardContent>
-      </Card>
-
-      {gallery.length > 0 && (
+      {/* Hero image */}
+      {project.image?.url && (
         <motion.div
-          className='grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3'
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
+          initial={{ opacity: 0, y: reduceMotion ? 0 : 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.55, delay: 0.1 }}
+          className='relative aspect-[16/9] overflow-hidden rounded-2xl border border-border/60 bg-muted'
         >
-          {gallery.map((src, i) => (
-            <div
-              key={i}
-              onClick={() => setSelectedImageIndex(i)}
-              className='relative aspect-[4/3] cursor-pointer overflow-hidden rounded-xl border shadow-sm transition-all hover:scale-[1.02] hover:shadow-lg'
-            >
-              <Image
-                src={src}
-                alt={`Gallery ${i + 1}`}
-                fill
-                className='object-cover'
-              />
-            </div>
-          ))}
+          <Image
+            src={project.image.url}
+            alt={localized.title}
+            fill
+            sizes='(max-width: 1024px) 100vw, 1024px'
+            className='object-contain p-3'
+            priority
+          />
         </motion.div>
       )}
 
+      {/* Meta: stack + links */}
+      <div className='grid gap-6 sm:grid-cols-2'>
+        <section className='rounded-xl border border-border/70 bg-card p-5'>
+          <h2 className='mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground'>
+            {t('common.projects.stack')}
+          </h2>
+          {tech.length > 0 ? (
+            <div className='flex flex-wrap gap-2'>
+              {tech.map((item) => (
+                <Badge
+                  key={item._id}
+                  variant='outline'
+                  className='gap-1.5 border-border/60 px-2.5 py-1 text-sm font-normal'
+                >
+                  <TechIcon
+                    techKey={
+                      item.icon?.toLowerCase?.() || item.name?.toLowerCase?.()
+                    }
+                    label={item.name}
+                    className='size-4 object-contain'
+                  />
+                  {item.name}
+                </Badge>
+              ))}
+            </div>
+          ) : (
+            <p className='text-sm text-muted-foreground'>—</p>
+          )}
+        </section>
+
+        <section className='rounded-xl border border-border/70 bg-card p-5'>
+          <h2 className='mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground'>
+            {t('common.projects.links')}
+          </h2>
+          {links.length > 0 ? (
+            <div className='flex flex-col gap-2'>
+              {links.map(([key, url]) => (
+                <a
+                  key={key}
+                  href={url as string}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='inline-flex items-center gap-2 text-sm font-medium text-foreground/80 transition-colors hover:text-brand'
+                >
+                  {repoKeys.includes(key) ? (
+                    <Github className='size-4' />
+                  ) : (
+                    <Globe className='size-4' />
+                  )}
+                  {t(`common.projects.${key}`)}
+                  <ArrowRight className='size-3.5 opacity-60' />
+                </a>
+              ))}
+            </div>
+          ) : (
+            <p className='text-sm text-muted-foreground'>
+              {t('common.projects.noLinks')}
+            </p>
+          )}
+        </section>
+      </div>
+
+      {/* Gallery */}
+      {gallery.length > 0 && (
+        <section className='space-y-4'>
+          <h2 className='text-sm font-semibold uppercase tracking-wide text-muted-foreground'>
+            {t('common.projects.gallery')}
+          </h2>
+          <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+            {gallery.map((src, i) => (
+              <button
+                key={i}
+                onClick={() => setLightbox(i)}
+                className='group relative aspect-[4/3] overflow-hidden rounded-xl border border-border/60 bg-muted transition-all hover:border-brand/40 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+              >
+                <Image
+                  src={src}
+                  alt={`${localized.title} — ${i + 1}`}
+                  fill
+                  sizes='(max-width: 640px) 100vw, 33vw'
+                  className='object-cover transition-transform duration-500 group-hover:scale-105'
+                />
+              </button>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Prev / next */}
+      {(prevProject || nextProject) && (
+        <nav className='grid gap-4 border-t border-border/60 pt-8 sm:grid-cols-2'>
+          {prevProject ? (
+            <button
+              onClick={() => router.push(`/project/${prevProject._id}`)}
+              className='group flex flex-col gap-1 rounded-xl border border-border/70 bg-card p-4 text-left transition-all hover:border-brand/40 hover:shadow-sm'
+            >
+              <span className='inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground'>
+                <ChevronLeft className='size-3.5' />
+                {t('common.previous')}
+              </span>
+              <span className='font-medium transition-colors group-hover:text-brand'>
+                {titleOf(prevProject)}
+              </span>
+            </button>
+          ) : (
+            <span />
+          )}
+          {nextProject && (
+            <button
+              onClick={() => router.push(`/project/${nextProject._id}`)}
+              className='group flex flex-col gap-1 rounded-xl border border-border/70 bg-card p-4 text-right transition-all hover:border-brand/40 hover:shadow-sm sm:items-end'
+            >
+              <span className='inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground'>
+                {t('common.next')}
+                <ChevronRight className='size-3.5' />
+              </span>
+              <span className='font-medium transition-colors group-hover:text-brand'>
+                {titleOf(nextProject)}
+              </span>
+            </button>
+          )}
+        </nav>
+      )}
+
+      {/* Lightbox */}
       <AnimatePresence>
-        {selectedImageIndex !== null && (
+        {lightbox !== null && (
           <motion.div
-            className='fixed inset-0 z-[999] flex items-center justify-center bg-black/90 backdrop-blur-sm'
+            className='fixed inset-0 z-[999] flex items-center justify-center bg-black/90 p-4 backdrop-blur-sm'
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            onClick={() => setSelectedImageIndex(null)}
+            onClick={() => setLightbox(null)}
           >
-            <div
-              className='relative max-h-[90vh] w-full max-w-5xl overflow-hidden rounded-2xl bg-black p-4 shadow-2xl'
+            <Button
+              variant='outline'
+              size='icon'
+              className='absolute right-4 top-4 z-10 rounded-full'
+              onClick={() => setLightbox(null)}
+              aria-label='Close'
+            >
+              <X className='size-5' />
+            </Button>
+
+            {gallery.length > 1 && (
+              <>
+                <Button
+                  variant='outline'
+                  size='icon'
+                  className='absolute left-4 top-1/2 z-10 -translate-y-1/2 rounded-full'
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setLightbox(
+                      (lightbox - 1 + gallery.length) % gallery.length
+                    );
+                  }}
+                  aria-label='Previous image'
+                >
+                  <ChevronLeft className='size-5' />
+                </Button>
+                <Button
+                  variant='outline'
+                  size='icon'
+                  className='absolute right-4 top-1/2 z-10 -translate-y-1/2 rounded-full'
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setLightbox((lightbox + 1) % gallery.length);
+                  }}
+                  aria-label='Next image'
+                >
+                  <ChevronRight className='size-5' />
+                </Button>
+              </>
+            )}
+
+            <motion.div
+              key={gallery[lightbox]}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ duration: 0.25 }}
+              className='relative flex max-h-[88vh] w-full max-w-5xl items-center justify-center'
               onClick={(e) => e.stopPropagation()}
             >
-              <Button
-                className='absolute right-3 top-3 z-10 rounded-full bg-black/60 p-2 text-white hover:bg-black/80'
-                onClick={() => setSelectedImageIndex(null)}
-              >
-                <X className='h-5 w-5' />
-              </Button>
-
-              {gallery.length > 1 && (
-                <>
-                  <Button
-                    onClick={() =>
-                      setSelectedImageIndex(
-                        (selectedImageIndex - 1 + gallery.length) %
-                          gallery.length
-                      )
-                    }
-                    className='absolute left-3 top-1/2 z-10 -translate-y-1/2 rounded-full bg-black/60 p-2 text-white hover:bg-black/80'
-                  >
-                    <ChevronLeft className='h-5 w-5' />
-                  </Button>
-                  <Button
-                    onClick={() =>
-                      setSelectedImageIndex(
-                        (selectedImageIndex + 1) % gallery.length
-                      )
-                    }
-                    className='absolute right-3 top-1/2 z-10 -translate-y-1/2 rounded-full bg-black/60 p-2 text-white hover:bg-black/80'
-                  >
-                    <ChevronRight className='h-5 w-5' />
-                  </Button>
-                </>
-              )}
-
-              <motion.div
-                key={gallery[selectedImageIndex]}
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                transition={{ duration: 0.3 }}
-                className='flex items-center justify-center'
-              >
-                <Image
-                  src={gallery[selectedImageIndex]}
-                  alt='Gallery image'
-                  width={1600}
-                  height={1200}
-                  className='max-h-[85vh] w-auto object-contain'
-                />
-              </motion.div>
-            </div>
+              <Image
+                src={gallery[lightbox]}
+                alt={`${localized.title} — ${lightbox + 1}`}
+                width={1600}
+                height={1200}
+                className='max-h-[88vh] w-auto rounded-lg object-contain'
+              />
+            </motion.div>
           </motion.div>
         )}
       </AnimatePresence>
-
-      {projects.length > 0 && (
-        <div className='flex flex-col items-center justify-center space-y-2 md:flex-row md:space-x-4'>
-          <Button onClick={goPrevProject} variant='outline'>
-            {t('common.previous')}
-          </Button>
-          <span className='text-sm text-muted-foreground'>
-            {t('common.projects.projectNumber', {
-              current: currentIndex + 1,
-              total,
-            })}
-          </span>
-          <Button onClick={goNextProject} variant='outline'>
-            {t('common.next')}
-          </Button>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/components/service/project.tsx
+++ b/src/components/service/project.tsx
@@ -1,225 +1,190 @@
 'use client';
 
 import { JSX, useEffect, useState } from 'react';
-import { Card, CardContent } from '@/components/ui/card';
-import {
-  Carousel,
-  CarouselContent,
-  CarouselItem,
-  CarouselNext,
-  CarouselPrevious,
-} from '@/components/ui/carousel';
 import { useLocale, useTranslations } from 'next-intl';
+import { motion, useReducedMotion } from 'framer-motion';
+import Image from 'next/image';
+import { ArrowRight, CheckCircle, Clock, PauseCircle, Rocket } from 'lucide-react';
+import { Link } from '@/i18n/navigation';
 import { client } from '@/sanity/lib/client';
 import { allProjectsQuery } from '@/sanity/queries/projects';
-import { motion } from 'framer-motion';
-import Image from 'next/image';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
 import TechIcon from '@/components/service/common/tech-icon';
-import type { Project, ProjectStatus } from '@/data/types/project';
-import { CheckCircle, Clock, PauseCircle, Rocket } from 'lucide-react';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
-import { useRouter } from '@/i18n/navigation';
+import type { Project as ProjectType, ProjectStatus } from '@/data/types/project';
 
-const statusIcons: Record<ProjectStatus, JSX.Element> = {
-  planned: <Clock className='inline h-4 w-4 text-blue-400' />,
-  in_progress: <Rocket className='inline h-4 w-4 text-yellow-500' />,
-  completed: <CheckCircle className='inline h-4 w-4 text-green-500' />,
-  on_hold: <PauseCircle className='inline h-4 w-4 text-gray-400' />,
+const statusIcon: Record<ProjectStatus, JSX.Element> = {
+  planned: <Clock className='size-3.5 text-sky-500' />,
+  in_progress: <Rocket className='size-3.5 text-amber-500' />,
+  completed: <CheckCircle className='size-3.5 text-emerald-500' />,
+  on_hold: <PauseCircle className='size-3.5 text-muted-foreground' />,
 };
+
+const MAX_TECH = 5;
+
+function ProjectCard({
+  project,
+  index,
+}: {
+  project: ProjectType;
+  index: number;
+}) {
+  const t = useTranslations();
+  const locale = useLocale();
+  const reduceMotion = useReducedMotion();
+
+  const localized = project.translations?.[locale] ||
+    project.translations?.en || { title: '', description: '' };
+  const tech = project.technologies ?? [];
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: reduceMotion ? 0 : 24 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.2 }}
+      transition={{
+        duration: 0.5,
+        delay: Math.min(index * 0.07, 0.28),
+        ease: [0.22, 1, 0.36, 1],
+      }}
+    >
+      <Link
+        href={`/project/${project._id}`}
+        className='group flex h-full flex-col overflow-hidden rounded-xl border border-border/70 bg-card shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-brand/40 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
+      >
+        <div className='relative aspect-[16/10] overflow-hidden bg-muted'>
+          {project.image?.url ? (
+            <Image
+              src={project.image.url}
+              alt={localized.title}
+              fill
+              sizes='(max-width: 640px) 100vw, 50vw'
+              className='object-cover transition-transform duration-500 group-hover:scale-[1.04]'
+            />
+          ) : (
+            <div className='flex h-full items-center justify-center text-sm text-muted-foreground'>
+              {localized.title}
+            </div>
+          )}
+
+          {project.status && (
+            <span className='absolute left-3 top-3 inline-flex items-center gap-1.5 rounded-full border border-border/60 bg-background/85 px-2.5 py-1 text-xs font-medium backdrop-blur-sm'>
+              {statusIcon[project.status]}
+              {t(`common.projects.statusLabels.${project.status}`)}
+            </span>
+          )}
+        </div>
+
+        <div className='flex flex-1 flex-col gap-3 p-5'>
+          <div className='space-y-1'>
+            {project.dateRange && (
+              <p className='text-xs font-medium uppercase tracking-wide text-muted-foreground'>
+                {project.dateRange}
+              </p>
+            )}
+            <h3 className='text-lg font-semibold tracking-tight transition-colors group-hover:text-brand'>
+              {localized.title}
+            </h3>
+          </div>
+
+          {localized.description && (
+            <p className='line-clamp-3 text-sm leading-relaxed text-muted-foreground'>
+              {localized.description}
+            </p>
+          )}
+
+          {tech.length > 0 && (
+            <div className='mt-auto flex flex-wrap gap-1.5 pt-1'>
+              {tech.slice(0, MAX_TECH).map((item) => (
+                <Badge
+                  key={item._id}
+                  variant='outline'
+                  className='gap-1.5 border-border/60 px-2 py-1 text-xs font-normal'
+                >
+                  <TechIcon
+                    techKey={item.icon?.toLowerCase?.() || item.name?.toLowerCase?.()}
+                    label={item.name}
+                    className='size-3.5 object-contain'
+                  />
+                  {item.name}
+                </Badge>
+              ))}
+              {tech.length > MAX_TECH && (
+                <Badge
+                  variant='outline'
+                  className='border-border/60 px-2 py-1 text-xs font-normal text-muted-foreground'
+                >
+                  +{tech.length - MAX_TECH}
+                </Badge>
+              )}
+            </div>
+          )}
+
+          <span className='inline-flex items-center gap-1.5 pt-1 text-sm font-medium text-brand'>
+            {t('common.projects.checkOut')}
+            <ArrowRight className='size-4 transition-transform duration-300 group-hover:translate-x-1' />
+          </span>
+        </div>
+      </Link>
+    </motion.div>
+  );
+}
+
+function ProjectCardSkeleton() {
+  return (
+    <div className='flex flex-col overflow-hidden rounded-xl border border-border/70 bg-card'>
+      <Skeleton className='aspect-[16/10] w-full rounded-none' />
+      <div className='flex flex-col gap-3 p-5'>
+        <Skeleton className='h-3 w-20' />
+        <Skeleton className='h-5 w-3/4' />
+        <Skeleton className='h-16 w-full' />
+        <div className='flex gap-1.5'>
+          <Skeleton className='h-6 w-16' />
+          <Skeleton className='h-6 w-16' />
+          <Skeleton className='h-6 w-16' />
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export function Project() {
   const t = useTranslations();
-  const locale = useLocale();
-  const router = useRouter();
-  const [projects, setProjects] = useState<Project[]>([]);
-  const [failedLogos, setFailedLogos] = useState(false);
+  const [projects, setProjects] = useState<ProjectType[] | null>(null);
 
   useEffect(() => {
-    client.fetch(allProjectsQuery).then(setProjects).catch(console.error);
+    client
+      .fetch(allProjectsQuery)
+      .then((res: ProjectType[]) => setProjects(res ?? []))
+      .catch((err) => {
+        console.error('Failed to fetch projects:', err);
+        setProjects([]);
+      });
   }, []);
 
   return (
-    <section id='projects' className='scroll-mt-24 space-y-12'>
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: false, amount: 0.3 }}
-        transition={{ duration: 0.6 }}
-        className='mx-auto max-w-3xl text-center'
-      >
-        <p className='text-sm font-medium uppercase tracking-wide text-primary/80'>
-          {t('common.projects.intro')}
+    <div className='space-y-8'>
+      <p className='mx-auto max-w-2xl text-center text-base leading-relaxed text-muted-foreground'>
+        {t('common.projects.intro')}
+      </p>
+
+      {projects === null ? (
+        <div className='grid gap-6 sm:grid-cols-2'>
+          {Array.from({ length: 4 }).map((_, i) => (
+            <ProjectCardSkeleton key={i} />
+          ))}
+        </div>
+      ) : projects.length === 0 ? (
+        <p className='text-center text-muted-foreground'>
+          {t('common.projects.empty')}
         </p>
-        <p className='mt-3 text-base leading-relaxed text-muted-foreground'>
-          {t('common.projects.content')}
-        </p>
-      </motion.div>
-
-      <Card className='overflow-hidden border border-border/60 bg-card/70 shadow-lg backdrop-blur-md'>
-        <CardContent className='p-4 md:p-8'>
-          {projects.length > 0 ? (
-            <Carousel className='mx-4 md:mx-8' opts={{ loop: true }}>
-              <CarouselContent>
-                {projects.map((project, idx) => {
-                  const localized = project.translations?.[locale] ||
-                    project.translations?.en || { title: '', description: '' };
-
-                  return (
-                    <CarouselItem key={project._id}>
-                      <motion.div
-                        initial={{ opacity: 0, scale: 0.97 }}
-                        whileInView={{ opacity: 1, scale: 1 }}
-                        viewport={{ once: false, amount: 0.3 }}
-                        transition={{ delay: idx * 0.1, duration: 0.5 }}
-                        className='flex min-h-[500px] flex-col items-center justify-center md:grid md:grid-cols-2 md:gap-10'
-                      >
-                        <motion.div
-                          initial={{ opacity: 0, x: -20 }}
-                          whileInView={{ opacity: 1, x: 0 }}
-                          transition={{ duration: 0.6 }}
-                          className='flex flex-col items-center justify-center space-y-5 text-center md:items-start md:space-y-6 md:text-left'
-                        >
-                          <h3 className='text-2xl font-semibold text-primary'>
-                            {localized.title}
-                          </h3>
-
-                          {project.status && (
-                            <div className='flex items-center justify-center gap-2 text-sm text-muted-foreground md:justify-start'>
-                              {statusIcons[project.status]}
-                              {t(
-                                `common.projects.statusLabels.${project.status}`
-                              )}
-                            </div>
-                          )}
-
-                          {project.image?.url && (
-                            <motion.div
-                              initial={{ opacity: 0, y: 20 }}
-                              whileInView={{ opacity: 1, y: 0 }}
-                              transition={{ duration: 0.6 }}
-                              viewport={{ once: false, amount: 0.3 }}
-                              className='relative mt-4 flex w-full justify-center md:hidden'
-                            >
-                              <div className='w-[95%] max-w-[640px] overflow-hidden rounded-2xl shadow-lg transition-all hover:shadow-xl sm:w-[90%]'>
-                                <Image
-                                  src={project.image.url}
-                                  alt={localized.title}
-                                  width={700}
-                                  height={500}
-                                  className='h-full w-full object-cover'
-                                />
-                                <div className='absolute inset-0 rounded-2xl bg-gradient-to-t from-background/30 via-transparent to-transparent' />
-                              </div>
-                            </motion.div>
-                          )}
-
-                          <p className='max-w-md leading-relaxed text-muted-foreground'>
-                            {localized.description}
-                          </p>
-
-                          {Array.isArray(project.technologies) &&
-                            project.technologies.length > 0 && (
-                              <div className='flex flex-wrap justify-center gap-3 md:justify-start'>
-                                {project.technologies.map((tech) => (
-                                  <TooltipProvider key={tech._id}>
-                                    <Tooltip>
-                                      <TooltipTrigger asChild>
-                                        <Badge
-                                          variant='outline'
-                                          className='flex items-center gap-2 px-3 py-2 text-sm transition-all hover:scale-105 hover:border-primary/60 hover:shadow-md'
-                                        >
-                                          <TechIcon
-                                            techKey={
-                                              tech.icon?.toLowerCase?.() ||
-                                              tech.name?.toLowerCase?.()
-                                            }
-                                            label={tech.name}
-                                            className='h-5 w-5 object-contain'
-                                            onError={() => setFailedLogos(true)}
-                                          />
-                                          <span>{tech.name}</span>
-                                        </Badge>
-                                      </TooltipTrigger>
-                                      <TooltipContent className='text-center'>
-                                        <div className='flex flex-col items-center space-y-1'>
-                                          <span className='text-sm font-medium'>
-                                            {tech.name}
-                                          </span>
-                                          {tech.level && (
-                                            <span className='text-xs text-muted-foreground'>
-                                              {t(
-                                                `common.skills.proficiency.${tech.level}`
-                                              )}
-                                            </span>
-                                          )}
-                                        </div>
-                                      </TooltipContent>
-                                    </Tooltip>
-                                  </TooltipProvider>
-                                ))}
-                              </div>
-                            )}
-
-                          <Button
-                            onClick={() =>
-                              router.push(`/project/${project._id}`)
-                            }
-                            variant='default'
-                            className='mt-6 rounded-md px-5 py-2 shadow-sm transition-transform hover:scale-105'
-                          >
-                            {t('common.projects.checkOut')}
-                          </Button>
-                        </motion.div>
-
-                        {project.image?.url && (
-                          <motion.div
-                            initial={{ opacity: 0, x: 20 }}
-                            whileInView={{ opacity: 1, x: 0 }}
-                            transition={{ duration: 0.6 }}
-                            viewport={{ once: false, amount: 0.3 }}
-                            className='relative hidden justify-center md:flex'
-                          >
-                            <div className='w-[95%] max-w-[640px] overflow-hidden rounded-2xl shadow-lg transition-all hover:shadow-xl sm:w-[90%] md:w-full'>
-                              <Image
-                                src={project.image.url}
-                                alt={localized.title}
-                                width={700}
-                                height={500}
-                                className='h-full w-full object-cover'
-                              />
-                              <div className='absolute inset-0 rounded-2xl bg-gradient-to-t from-background/30 via-transparent to-transparent' />
-                            </div>
-                          </motion.div>
-                        )}
-                      </motion.div>
-                    </CarouselItem>
-                  );
-                })}
-              </CarouselContent>
-
-              <CarouselPrevious className='transition-transform duration-300 hover:scale-110' />
-              <CarouselNext className='transition-transform duration-300 hover:scale-110' />
-            </Carousel>
-          ) : (
-            <p className='text-center text-muted-foreground'>
-              {t('common.projects.empty')}
-            </p>
-          )}
-
-          {failedLogos && (
-            <p className='mt-4 text-center text-xs text-muted-foreground'>
-              {t('common.skills.logoFallbackNote')}
-            </p>
-          )}
-        </CardContent>
-      </Card>
-    </section>
+      ) : (
+        <div className='grid gap-6 sm:grid-cols-2'>
+          {projects.map((project, index) => (
+            <ProjectCard key={project._id} project={project} index={index} />
+          ))}
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/data/types/project.ts
+++ b/src/data/types/project.ts
@@ -17,9 +17,11 @@ export type ProjectStatus = 'planned' | 'in_progress' | 'completed' | 'on_hold';
 
 export interface Project {
   _id: string;
+  _createdAt?: string;
   translations: Record<string, ProjectTranslation>;
   status?: ProjectStatus;
   dateRange?: string;
+  date?: string;
   image?: { url: string };
   gallery?: { url: string }[];
   technologies?: Skill[];

--- a/src/sanity/queries/projects.ts
+++ b/src/sanity/queries/projects.ts
@@ -1,9 +1,10 @@
-export const allProjectsQuery = `
-*[_type == "project"]{
+const projectProjection = `
   _id,
+  _createdAt,
   translations,
   status,
   dateRange,
+  date,
   image { "url": asset->url },
   gallery[] { "url": asset->url },
   technologies[]->{
@@ -14,24 +15,12 @@ export const allProjectsQuery = `
     category
   },
   links
-}
+`;
+
+export const allProjectsQuery = `
+*[_type == "project"]{${projectProjection}} | order(coalesce(date, _createdAt) desc)
 `;
 
 export const projectByIdQuery = `
-*[_type == "project" && _id == $id][0]{
-  _id,
-  translations,
-  status,
-  dateRange,
-  image { "url": asset->url },
-  gallery[] { "url": asset->url },
-  technologies[]->{
-    _id,
-    name,
-    icon,
-    level,
-    category
-  },
-  links
-}
+*[_type == "project" && _id == $id][0]{${projectProjection}}
 `;

--- a/src/sanity/schemaTypes/project.ts
+++ b/src/sanity/schemaTypes/project.ts
@@ -73,7 +73,20 @@ export const project = defineType({
       initialValue: 'planned',
     }),
 
-    defineField({ name: 'dateRange', title: 'Date Range', type: 'string' }),
+    defineField({
+      name: 'dateRange',
+      title: 'Date Range (display label)',
+      type: 'string',
+      description: 'Human-readable period shown on the project, e.g. "2024".',
+    }),
+
+    defineField({
+      name: 'date',
+      title: 'Project Date (sorting)',
+      type: 'date',
+      description:
+        'Used to order projects from newest to oldest. If left empty, the document creation date is used as a fallback.',
+    }),
 
     defineField({
       name: 'image',


### PR DESCRIPTION
Closes #32 — troisième chantier de la V2.

## Tri des projets
- Champ optionnel **Project Date** ajouté au schéma Sanity.
- Toutes les requêtes projet ordonnées par `coalesce(date, _createdAt) desc` → **du plus récent au plus ancien**, strictement.
- Non destructif : les projets existants se trient immédiatement via le fallback sur la date de création du document. La date explicite reste optionnelle pour affiner.
- Le tri s'applique partout : grille de l'accueil et navigation précédent/suivant en page détail (même requête `allProjectsQuery`).

## Section Projets (accueil)
- Le carousel une-slide-à-la-fois est remplacé par une **grille de cartes case-study** responsive (1 colonne mobile, 2 desktop).
- Hiérarchie claire par carte : cover, statut, période, titre, résumé (3 lignes), stack (5 max + compteur).
- Carte entièrement cliquable, état hover sobre (élévation, accent), focus visible.
- Skeletons de chargement.

## Page de détail
- Le tableau de métadonnées est remplacé par une mise en page **case-study** : lien retour, en-tête (statut + période + titre + description), image héro, panneaux Stack et Links lisibles, galerie, navigation précédent/suivant affichant les titres.
- Lightbox conservée, contrôles alignés sur le style de bouton partagé.

## Correctifs
- Suppression de l'`id` dupliqué `projects` (présent à la fois sur `SectionWrapper` et le composant).
- La V1 référençait `common.projects.noStack`, clé absente des fichiers de traduction → remplacé par un état neutre.

## Impacts
- Schéma Sanity : un champ optionnel ajouté, données existantes intactes.
- Build OK, type-check OK, aucune erreur runtime introduite.