### PR TITLE
V2 — Storytelling & structure des sections

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -38,10 +38,6 @@ export default function HomePage() {
         <AboutMe />
       </SectionWrapper>
 
-      <SectionWrapper id='languages' titleKey='common.header.languages'>
-        <Language />
-      </SectionWrapper>
-
       <SectionWrapper id='motivation' titleKey='common.header.motivation'>
         <Motivation />
       </SectionWrapper>
@@ -56,6 +52,10 @@ export default function HomePage() {
 
       <SectionWrapper id='projects' titleKey='common.header.projects'>
         <Project />
+      </SectionWrapper>
+
+      <SectionWrapper id='languages' titleKey='common.header.languages'>
+        <Language />
       </SectionWrapper>
 
       <SectionWrapper id='contact' titleKey='common.header.contact'>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -37,11 +37,11 @@ export function Header({ logoSrc, logoAlt = 'Logo', locale }: HeaderProps) {
 
   const items = [
     { id: 'about', label: t('common.header.about') },
-    { id: 'languages', label: t('common.header.languages') },
     { id: 'motivation', label: t('common.header.motivation') },
     { id: 'experience', label: t('common.header.experience') },
     { id: 'skills', label: t('common.header.skills') },
     { id: 'projects', label: t('common.header.projects') },
+    { id: 'languages', label: t('common.header.languages') },
     { id: 'contact', label: t('common.header.contact') },
   ];
 

--- a/src/components/service/about-me.tsx
+++ b/src/components/service/about-me.tsx
@@ -61,10 +61,7 @@ export function AboutMe() {
   ];
 
   return (
-    <section
-      id='about'
-      className='flex flex-col gap-10 md:grid md:grid-cols-2 md:items-start md:gap-8'
-    >
+    <div className='flex flex-col gap-10 md:grid md:grid-cols-2 md:items-start md:gap-8'>
       {/* Left column - About me text */}
       <motion.div
         ref={textRef}
@@ -204,6 +201,6 @@ export function AboutMe() {
           </CardContent>
         </Card>
       </motion.div>
-    </section>
+    </div>
   );
 }

--- a/src/components/service/contact-me.tsx
+++ b/src/components/service/contact-me.tsx
@@ -74,12 +74,12 @@ export function ContactMe() {
   const linkedinLink = process.env.NEXT_PUBLIC_LINKEDIN_URL || '#';
 
   return (
-    <section id='contact' className='scroll-mt-24'>
-      <motion.div
-        initial={{ opacity: 0, y: 25 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6 }}
-      >
+    <motion.div
+      initial={{ opacity: 0, y: 25 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.2 }}
+      transition={{ duration: 0.6 }}
+    >
         <Card className='rounded-2xl border border-border/60 bg-card/80 shadow-lg backdrop-blur-md'>
           <CardHeader className='flex flex-col items-center gap-4'>
             <motion.div
@@ -178,7 +178,6 @@ export function ContactMe() {
             </motion.form>
           </CardContent>
         </Card>
-      </motion.div>
-    </section>
+    </motion.div>
   );
 }

--- a/src/components/service/experience.tsx
+++ b/src/components/service/experience.tsx
@@ -31,30 +31,17 @@ export function Experience() {
 
   if (!experiences.length)
     return (
-      <section id='experience' className='scroll-mt-24'>
-        <Card className='border-2 border-primary'>
-          <CardHeader />
-          <CardContent>{t('common.experience.empty')}</CardContent>
-        </Card>
-      </section>
+      <Card className='border-border/60'>
+        <CardHeader />
+        <CardContent>{t('common.experience.empty')}</CardContent>
+      </Card>
     );
 
   return (
-    <section id='experience' className='scroll-mt-24 space-y-10'>
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: false, amount: 0.3 }}
-        transition={{ duration: 0.6 }}
-        className='mx-auto max-w-3xl text-center'
-      >
-        <p className='text-sm font-medium uppercase tracking-wide text-primary/80'>
-          {t('common.experience.intro')}
-        </p>
-        <p className='mt-3 text-base leading-relaxed text-muted-foreground'>
-          {t('common.experience.content')}
-        </p>
-      </motion.div>
+    <div className='space-y-10'>
+      <p className='mx-auto max-w-2xl text-center text-base leading-relaxed text-muted-foreground'>
+        {t('common.experience.intro')}
+      </p>
 
       <div className='grid gap-8 sm:grid-cols-2'>
         {experiences.map((exp, idx) => {
@@ -67,8 +54,8 @@ export function Experience() {
               key={exp._id}
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: false, amount: 0.3 }}
-              transition={{ delay: idx * 0.1, duration: 0.5 }}
+              viewport={{ once: true, amount: 0.2 }}
+              transition={{ delay: Math.min(idx * 0.08, 0.32), duration: 0.5 }}
             >
               <Card className='group h-full rounded-2xl border border-border/60 bg-card/70 shadow-lg backdrop-blur-sm transition hover:-translate-y-1 hover:shadow-xl'>
                 <CardHeader className='flex flex-col items-center space-y-2 text-center'>
@@ -150,6 +137,6 @@ export function Experience() {
           {t('common.skills.logoFallbackNote')}
         </p>
       )}
-    </section>
+    </div>
   );
 }

--- a/src/components/service/language.tsx
+++ b/src/components/service/language.tsx
@@ -31,7 +31,7 @@ export function Language() {
   }, []);
 
   return (
-    <section id='languages' className='scroll-mt-24 space-y-4'>
+    <div className='space-y-4'>
       <Card className='border-2 p-4'>
         <CardContent className='space-y-3'>
           {languages.length > 0 ? (
@@ -58,6 +58,6 @@ export function Language() {
           )}
         </CardContent>
       </Card>
-    </section>
+    </div>
   );
 }

--- a/src/components/service/motivation.tsx
+++ b/src/components/service/motivation.tsx
@@ -22,15 +22,12 @@ export function Motivation() {
   }, [locale]);
 
   return (
-    <section
-      id='motivation'
-      className='grid scroll-mt-24 grid-cols-1 items-center gap-12 md:grid-cols-2'
-    >
+    <div className='grid grid-cols-1 items-center gap-12 md:grid-cols-2'>
       <motion.div
         initial={{ opacity: 0, scale: 0.95 }}
         whileInView={{ opacity: 1, scale: 1 }}
         transition={{ duration: 0.8, ease: 'easeOut' }}
-        viewport={{ once: false, amount: 0.3 }}
+        viewport={{ once: true, amount: 0.3 }}
         className='flex justify-center'
       >
         {motivation?.image?.url ? (
@@ -58,7 +55,7 @@ export function Motivation() {
       <motion.div
         initial={{ opacity: 0, y: 30 }}
         whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: false, amount: 0.3 }}
+        viewport={{ once: true, amount: 0.3 }}
         transition={{ duration: 0.7, ease: 'easeOut' }}
       >
         <Card className='rounded-2xl border border-border/60 bg-card/70 shadow-lg backdrop-blur-md transition hover:shadow-xl'>
@@ -85,6 +82,6 @@ export function Motivation() {
           </CardContent>
         </Card>
       </motion.div>
-    </section>
+    </div>
   );
 }

--- a/src/components/service/skill.tsx
+++ b/src/components/service/skill.tsx
@@ -85,21 +85,10 @@ export function Skill() {
   );
 
   return (
-    <section id='skills' className='scroll-mt-24 space-y-16'>
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: false, amount: 0.3 }}
-        transition={{ duration: 0.6 }}
-        className='mx-auto max-w-3xl text-center'
-      >
-        <p className='text-sm font-medium uppercase tracking-wide text-primary/80'>
-          {t('common.skills.intro')}
-        </p>
-        <p className='mt-3 text-base leading-relaxed text-muted-foreground'>
-          {t('common.skills.content')}
-        </p>
-      </motion.div>
+    <div className='space-y-8'>
+      <p className='mx-auto max-w-2xl text-center text-base leading-relaxed text-muted-foreground'>
+        {t('common.skills.intro')}
+      </p>
 
       <Card className='border border-border/60 bg-card/70 shadow-lg backdrop-blur-md'>
         <CardContent className='pt-6'>
@@ -135,12 +124,12 @@ export function Skill() {
             </TabsContent>
           </Tabs>
           {failedLogos && (
-            <p className='text-center text-xs text-gray-400'>
+            <p className='text-center text-xs text-muted-foreground'>
               {t('common.skills.logoFallbackNote')}
             </p>
           )}
         </CardContent>
       </Card>
-    </section>
+    </div>
   );
 }


### PR DESCRIPTION
Closes #34 — quatrième chantier de la V2.

## Structure
- Réordonnancement des sections de l'accueil : About, Motivation, Experience, Skills, Projects, Languages, Contact. La section « langues parlées » n'interrompt plus le fil entre About et Motivation.
- La navigation (desktop + drawer mobile) suit le même ordre.

## Contenu
- Suppression des paragraphes `content` génériques d'Experience et Skills (ton « IA », redondants). Le `intro`, déjà concis, devient le sous-titre de section.
- Aucune réécriture du contenu Sanity (about, motivation) — il appartient à l'éditeur.

## Correctifs
- `id` de section dupliqués supprimés : ils étaient présents à la fois sur `SectionWrapper` et sur le composant interne (about, motivation, experience, skills, projects, languages, contact). Le wrapper en est désormais seul propriétaire.
- Animations au scroll restantes passées en `once: true` (cohérence avec le chantier 1).

## Impacts
- UI : ordre et en-têtes de sections. Faible risque.
- Données : aucun changement Sanity.
- Build OK, type-check OK.