### PR TITLE
V2 — SEO, metadata & Open Graph

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import createNextIntlPlugin from 'next-intl/plugin';
 
 const nextConfig: NextConfig = {
   images: {
+    formats: ['image/avif', 'image/webp'],
     remotePatterns: [
       {
         protocol: 'https',

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -10,6 +10,8 @@ import { Toaster } from 'sonner';
 import { Footer } from '@/components/layout/footer';
 import { ActiveSectionProvider } from '@/hooks/use-active-section';
 import { Inter } from 'next/font/google';
+import type { Metadata } from 'next';
+import { getBaseUrl, ogLocale, seoContent, siteName } from '@/lib/seo';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -19,15 +21,57 @@ const inter = Inter({
 
 type Params = Promise<{ locale: string }>;
 
-export async function generateMetadata({ params }: { params: Params }) {
-  const locale = await params;
+export async function generateMetadata({
+  params,
+}: {
+  params: Params;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const loc = hasLocale(routing.locales, locale)
+    ? locale
+    : routing.defaultLocale;
+  const base = getBaseUrl();
+  const { title, description } = seoContent[loc];
+  const languages = Object.fromEntries(
+    routing.locales.map((l) => [l, `${base}/${l}`])
+  );
 
   return {
-    title: "Ramzi's Portfolio",
-    description: `Localized portfolio for ${locale}`,
-    icons: {
-      icon: '/images/logo.jpg',
+    metadataBase: new URL(base),
+    title: { default: title, template: `%s — ${siteName}` },
+    description,
+    applicationName: siteName,
+    authors: [{ name: siteName }],
+    creator: siteName,
+    keywords: [
+      'Ramzi Benmansour',
+      'portfolio',
+      'web developer',
+      'software engineer',
+      'frontend',
+      'React',
+      'Next.js',
+      'TypeScript',
+    ],
+    alternates: {
+      canonical: `${base}/${loc}`,
+      languages: { ...languages, 'x-default': `${base}/${routing.defaultLocale}` },
     },
+    openGraph: {
+      type: 'website',
+      siteName,
+      locale: ogLocale[loc],
+      url: `${base}/${loc}`,
+      title,
+      description,
+    },
+    twitter: { card: 'summary_large_image', title, description },
+    robots: {
+      index: true,
+      follow: true,
+      googleBot: { index: true, follow: true },
+    },
+    icons: { icon: '/images/logo.jpg' },
   };
 }
 
@@ -49,9 +93,25 @@ export default async function LocaleLayout({ children, params }: Props) {
 
   const direction = locale === 'ar' ? 'rtl' : 'ltr';
 
+  const baseUrl = getBaseUrl();
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: siteName,
+    url: `${baseUrl}/${locale}`,
+    sameAs: [
+      process.env.NEXT_PUBLIC_GITHUB_URL,
+      process.env.NEXT_PUBLIC_LINKEDIN_URL,
+    ].filter(Boolean),
+  };
+
   return (
     <html lang={locale} dir={direction} className={inter.variable}>
       <body className='font-sans antialiased'>
+        <script
+          type='application/ld+json'
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
         <NextIntlClientProvider messages={messages} locale={locale}>
           <ThemeProvider
             attribute='class'

--- a/src/app/[locale]/opengraph-image.tsx
+++ b/src/app/[locale]/opengraph-image.tsx
@@ -1,0 +1,65 @@
+import { ImageResponse } from 'next/og';
+
+export const alt = 'Ramzi Benmansour — Portfolio';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default function OpengraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          padding: '90px',
+          background:
+            'linear-gradient(135deg, #0b0b12 0%, #14141f 55%, #201c42 100%)',
+          color: '#fafafa',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '16px',
+            color: '#a5b4fc',
+            fontSize: 30,
+            letterSpacing: 5,
+          }}
+        >
+          <div
+            style={{
+              width: 48,
+              height: 6,
+              background: '#6366f1',
+              borderRadius: 4,
+              display: 'flex',
+            }}
+          />
+          PORTFOLIO
+        </div>
+
+        <div
+          style={{
+            fontSize: 108,
+            fontWeight: 700,
+            marginTop: 30,
+            lineHeight: 1.05,
+            letterSpacing: -2,
+          }}
+        >
+          Ramzi Benmansour
+        </div>
+
+        <div style={{ fontSize: 38, color: '#a1a1aa', marginTop: 30 }}>
+          Projects · Experience · Skills
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/src/app/[locale]/project/[id]/page.tsx
+++ b/src/app/[locale]/project/[id]/page.tsx
@@ -1,18 +1,59 @@
+import { cache } from 'react';
+import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
+import { hasLocale } from 'next-intl';
 import { ProjectDetail } from '@/components/service/project-detail';
 import { client } from '@/sanity/lib/client';
 import type { Project } from '@/data/types/project';
 import { projectByIdQuery } from '@/sanity/queries/projects';
+import { routing } from '@/i18n/routing';
+import { getBaseUrl, seoContent, siteName } from '@/lib/seo';
 
 type Params = Promise<{ locale: string; id: string }>;
 
-export default async function ProjectPage({ params }: { params: Params }) {
-  const { locale, id } = await params;
+const getProject = cache((id: string) =>
+  client.fetch<Project | null>(projectByIdQuery, { id })
+);
 
-  const project = await client.fetch<Project | null>(projectByIdQuery, {
-    id,
-    locale,
-  });
+export async function generateMetadata({
+  params,
+}: {
+  params: Params;
+}): Promise<Metadata> {
+  const { locale, id } = await params;
+  const project = await getProject(id);
+
+  if (!project) return {};
+
+  const loc = hasLocale(routing.locales, locale)
+    ? locale
+    : routing.defaultLocale;
+  const localized = project.translations?.[loc] || project.translations?.en;
+  const title = localized?.title?.trim() || siteName;
+  const description =
+    localized?.description?.trim().slice(0, 200) || seoContent[loc].description;
+  const url = `${getBaseUrl()}/${loc}/project/${id}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      type: 'article',
+      title,
+      description,
+      url,
+      images: project.image?.url
+        ? [{ url: project.image.url }]
+        : undefined,
+    },
+    twitter: { card: 'summary_large_image', title, description },
+  };
+}
+
+export default async function ProjectPage({ params }: { params: Params }) {
+  const { id } = await params;
+  const project = await getProject(id);
 
   if (!project) return notFound();
 

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from 'next';
+import { getBaseUrl } from '@/lib/seo';
+
+export default function robots(): MetadataRoute.Robots {
+  const base = getBaseUrl();
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/studio', '/api/'],
+    },
+    sitemap: `${base}/sitemap.xml`,
+    host: base,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,35 @@
+import type { MetadataRoute } from 'next';
+import { routing } from '@/i18n/routing';
+import { getBaseUrl } from '@/lib/seo';
+import { client } from '@/sanity/lib/client';
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const base = getBaseUrl();
+  const now = new Date();
+
+  const home: MetadataRoute.Sitemap = routing.locales.map((locale) => ({
+    url: `${base}/${locale}`,
+    lastModified: now,
+    changeFrequency: 'monthly',
+    priority: 1,
+  }));
+
+  let projects: { _id: string; _updatedAt?: string }[] = [];
+
+  try {
+    projects = await client.fetch(`*[_type == "project"]{ _id, _updatedAt }`);
+  } catch {
+    projects = [];
+  }
+
+  const projectPages: MetadataRoute.Sitemap = routing.locales.flatMap((locale) =>
+    projects.map((p) => ({
+      url: `${base}/${locale}/project/${p._id}`,
+      lastModified: p._updatedAt ? new Date(p._updatedAt) : now,
+      changeFrequency: 'monthly' as const,
+      priority: 0.7,
+    }))
+  );
+
+  return [...home, ...projectPages];
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,50 @@
+import type { Locale } from '@/i18n/routing';
+
+export const siteName = 'Ramzi Benmansour';
+
+/** Absolute base URL of the site, used for canonical/OG/sitemap URLs. */
+export function getBaseUrl(): string {
+  const fromEnv = process.env.NEXT_PUBLIC_BASE_URL;
+
+  if (fromEnv && /^https?:\/\//.test(fromEnv)) {
+    return fromEnv.replace(/\/$/, '');
+  }
+
+  if (process.env.VERCEL_PROJECT_PRODUCTION_URL) {
+    return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
+  }
+
+  return 'http://localhost:8000';
+}
+
+export const seoContent: Record<Locale, { title: string; description: string }> =
+  {
+    en: {
+      title: `${siteName} — Portfolio`,
+      description:
+        'Portfolio of Ramzi Benmansour: selected projects, professional experience and technical skills in web development.',
+    },
+    fr: {
+      title: `${siteName} — Portfolio`,
+      description:
+        'Portfolio de Ramzi Benmansour : projets, expériences professionnelles et compétences techniques en développement web.',
+    },
+    ar: {
+      title: `${siteName} — أعمالي`,
+      description:
+        'أعمال رمزي بن منصور: مشاريع مختارة وخبرات مهنية ومهارات تقنية في تطوير الويب.',
+    },
+    kr: {
+      title: `${siteName} — 포트폴리오`,
+      description:
+        '람지 벤만수르의 포트폴리오: 웹 개발 프로젝트, 경력, 기술 역량을 소개합니다.',
+    },
+  };
+
+/** Maps an app locale to a BCP-47 / OpenGraph locale tag. */
+export const ogLocale: Record<Locale, string> = {
+  en: 'en_US',
+  fr: 'fr_FR',
+  ar: 'ar_AR',
+  kr: 'ko_KR',
+};


### PR DESCRIPTION
Closes #36 — cinquième chantier de la V2.

## Métadonnées
- `generateMetadata` complet et localisé dans le layout : `metadataBase`, titre avec template, description, `canonical`, `hreflang` (4 locales + `x-default`), Open Graph, carte Twitter, directives `robots`.
- Bug corrigé : la description était « Localized portfolio for [object Object] ».
- Données structurées JSON-LD (`Person`) injectées dans le layout.

## Pages projet
- Chaque page projet émet ses propres titre, description, `canonical` et image Open Graph à partir du contenu du projet.
- Le fetch Sanity est partagé entre `generateMetadata` et la page via un loader `cache()` (pas de double requête).

## Fichiers SEO
- `robots.ts` : autorise l'indexation, bloque `/studio` et `/api/`, référence le sitemap.
- `sitemap.ts` : accueil par locale + pages projet, généré dynamiquement.
- `opengraph-image.tsx` : image OG 1200×630 de marque générée via `next/og`.
- AVIF/WebP activés pour l'optimisation d'images.

## Vérification
- Build de production OK, type-check OK (6 routes statiques, dont `/robots.txt` et `/sitemap.xml`).
- `robots.txt`, `sitemap.xml` (XML valide) et l'image OG (`200`, `image/png`) vérifiés au runtime.

## Hors périmètre
Migration des sections en Server Components (rendu serveur du contenu) — chantier suivant.