### PR TITLE
V2 — Rendu serveur des sections (SSR)

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -106,7 +106,12 @@ export default async function LocaleLayout({ children, params }: Props) {
   };
 
   return (
-    <html lang={locale} dir={direction} className={inter.variable}>
+    <html
+      lang={locale}
+      dir={direction}
+      className={inter.variable}
+      suppressHydrationWarning
+    >
       <body className='font-sans antialiased'>
         <script
           type='application/ld+json'

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,61 +1,101 @@
-'use client';
-
-import { AboutMe } from '@/components/service/about-me';
-import { ContactMe } from '@/components/service/contact-me';
-import { Experience } from '@/components/service/experience';
-import { Language } from '@/components/service/language';
-import { Motivation } from '@/components/service/motivation';
-import { Project } from '@/components/service/project';
-import { Skill } from '@/components/service/skill';
-import { useTranslations } from 'next-intl';
+import { setRequestLocale } from 'next-intl/server';
 import SectionWrapper from '@/components/layout/section-wrapper';
+import { ScrollRestoration } from '@/components/layout/scroll-restoration';
 import { Hero } from '@/components/service/hero';
-import { useEffect } from 'react';
+import { AboutMe } from '@/components/service/about-me';
+import { Motivation } from '@/components/service/motivation';
+import { Experience } from '@/components/service/experience';
+import { Skill } from '@/components/service/skill';
+import { Project } from '@/components/service/project';
+import { Language } from '@/components/service/language';
+import { ContactMe } from '@/components/service/contact-me';
+import { client } from '@/sanity/lib/client';
+import {
+  aboutMeQuery,
+  currentStatusQuery,
+  heroQuery,
+  motivationQuery,
+} from '@/sanity/queries/info';
+import { allExperiencesQuery } from '@/sanity/queries/experiences';
+import { allSkillsQuery } from '@/sanity/queries/skills';
+import { allProjectsQuery } from '@/sanity/queries/projects';
+import { allLanguagesQuery } from '@/sanity/queries/languages';
+import type {
+  AboutMe as AboutMeType,
+  CurrentStatus,
+  Hero as HeroType,
+  Motivation as MotivationType,
+} from '@/data/types/info';
+import type { Experience as ExperienceType } from '@/data/types/experience';
+import type { Skill as SkillType } from '@/data/types/skill';
+import type { Project as ProjectType } from '@/data/types/project';
+import type { Language as LanguageType } from '@/components/service/language';
 
-export default function HomePage() {
-  const t = useTranslations();
+export const dynamic = 'force-dynamic';
 
-  useEffect(() => {
-    const targetId = sessionStorage.getItem('scrollTarget');
+type Params = Promise<{ locale: string }>;
 
-    if (targetId) {
-      sessionStorage.removeItem('scrollTarget');
+export default async function HomePage({ params }: { params: Params }) {
+  const { locale } = await params;
 
-      setTimeout(() => {
-        const el = document.getElementById(targetId);
+  setRequestLocale(locale);
 
-        if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      }, 800);
-    } else {
-      sessionStorage.removeItem('scrollTarget');
-    }
-  }, []);
+  const [hero, about, status, motivation, experiences, skills, projects, languages] =
+    await Promise.all([
+      client
+        .fetch<HeroType | null>(heroQuery, { locale })
+        .catch(() => null),
+      client
+        .fetch<AboutMeType | null>(aboutMeQuery, { locale })
+        .catch(() => null),
+      client
+        .fetch<CurrentStatus | null>(currentStatusQuery, { locale })
+        .catch(() => null),
+      client
+        .fetch<MotivationType | null>(motivationQuery, { locale })
+        .catch(() => null),
+      client
+        .fetch<ExperienceType[]>(allExperiencesQuery)
+        .catch(() => [] as ExperienceType[]),
+      client
+        .fetch<SkillType[]>(allSkillsQuery)
+        .catch(() => [] as SkillType[]),
+      client
+        .fetch<ProjectType[]>(allProjectsQuery)
+        .catch(() => [] as ProjectType[]),
+      client
+        .fetch<LanguageType[]>(allLanguagesQuery)
+        .catch(() => [] as LanguageType[]),
+    ]);
 
   return (
     <main className='space-y-32'>
-      <Hero />
+      <ScrollRestoration />
+
+      <Hero hero={hero} />
+
       <SectionWrapper id='about' titleKey='common.header.about'>
-        <AboutMe />
+        <AboutMe about={about} status={status} />
       </SectionWrapper>
 
       <SectionWrapper id='motivation' titleKey='common.header.motivation'>
-        <Motivation />
+        <Motivation motivation={motivation} />
       </SectionWrapper>
 
       <SectionWrapper id='experience' titleKey='common.header.experience'>
-        <Experience />
+        <Experience experiences={experiences} />
       </SectionWrapper>
 
       <SectionWrapper id='skills' titleKey='common.header.skills'>
-        <Skill />
+        <Skill skills={skills} />
       </SectionWrapper>
 
       <SectionWrapper id='projects' titleKey='common.header.projects'>
-        <Project />
+        <Project projects={projects} />
       </SectionWrapper>
 
       <SectionWrapper id='languages' titleKey='common.header.languages'>
-        <Language />
+        <Language languages={languages} />
       </SectionWrapper>
 
       <SectionWrapper id='contact' titleKey='common.header.contact'>

--- a/src/app/[locale]/project/[id]/page.tsx
+++ b/src/app/[locale]/project/[id]/page.tsx
@@ -5,7 +5,7 @@ import { hasLocale } from 'next-intl';
 import { ProjectDetail } from '@/components/service/project-detail';
 import { client } from '@/sanity/lib/client';
 import type { Project } from '@/data/types/project';
-import { projectByIdQuery } from '@/sanity/queries/projects';
+import { allProjectsQuery, projectByIdQuery } from '@/sanity/queries/projects';
 import { routing } from '@/i18n/routing';
 import { getBaseUrl, seoContent, siteName } from '@/lib/seo';
 
@@ -53,13 +53,18 @@ export async function generateMetadata({
 
 export default async function ProjectPage({ params }: { params: Params }) {
   const { id } = await params;
-  const project = await getProject(id);
+  const [project, siblings] = await Promise.all([
+    getProject(id),
+    client
+      .fetch<Project[]>(allProjectsQuery)
+      .catch(() => [] as Project[]),
+  ]);
 
   if (!project) return notFound();
 
   return (
     <main className='min-h-screen px-5 py-10 sm:px-6 md:py-14'>
-      <ProjectDetail project={project} />
+      <ProjectDetail project={project} siblings={siblings} />
     </main>
   );
 }

--- a/src/components/layout/scroll-restoration.tsx
+++ b/src/components/layout/scroll-restoration.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Scrolls to a section saved in sessionStorage by the header when
+ * navigating back to the home page from another route.
+ */
+export function ScrollRestoration() {
+  useEffect(() => {
+    const targetId = sessionStorage.getItem('scrollTarget');
+
+    sessionStorage.removeItem('scrollTarget');
+
+    if (!targetId) return;
+
+    const timer = setTimeout(() => {
+      const el = document.getElementById(targetId);
+
+      if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }, 600);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return null;
+}

--- a/src/components/service/about-me.tsx
+++ b/src/components/service/about-me.tsx
@@ -1,34 +1,22 @@
 'use client';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
-import { useLocale } from 'next-intl';
 import { useEffect, useRef, useState } from 'react';
-import { client } from '@/sanity/lib/client';
-import { aboutMeQuery, currentStatusQuery } from '@/sanity/queries/info';
 import type { AboutMe as AboutMeType, CurrentStatus } from '@/data/types/info';
 import { Github, Linkedin, MapPin, Briefcase } from 'lucide-react';
 import { motion } from 'framer-motion';
 
-export function AboutMe() {
-  const locale = useLocale();
-  const [about, setAbout] = useState<AboutMeType | null>(null);
-  const [status, setStatus] = useState<CurrentStatus | null>(null);
+export function AboutMe({
+  about,
+  status,
+}: {
+  about: AboutMeType | null;
+  status: CurrentStatus | null;
+}) {
   const [contentHeight, setContentHeight] = useState<number | null>(null);
   const textRef = useRef<HTMLDivElement>(null);
 
   const githubUrl = process.env.NEXT_PUBLIC_GITHUB_URL || '#';
   const linkedinUrl = process.env.NEXT_PUBLIC_LINKEDIN_URL || '#';
-
-  useEffect(() => {
-    Promise.all([
-      client.fetch(aboutMeQuery, { locale }),
-      client.fetch(currentStatusQuery, { locale }),
-    ])
-      .then(([aboutData, statusData]) => {
-        setAbout(aboutData);
-        setStatus(statusData);
-      })
-      .catch(console.error);
-  }, [locale]);
 
   useEffect(() => {
     if (!textRef.current) return;
@@ -67,33 +55,21 @@ export function AboutMe() {
         ref={textRef}
         initial={{ opacity: 0, y: 20 }}
         whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: false, amount: 0.25 }}
+        viewport={{ once: true, amount: 0.25 }}
         transition={{ duration: 0.6 }}
         className='h-full'
       >
         <Card className='h-full rounded-2xl border border-border/60 bg-card/70 shadow-lg backdrop-blur-md transition hover:shadow-xl'>
           <CardHeader className='space-y-3'>
-            <motion.p
-              initial={{ opacity: 0, y: 10 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: false, amount: 0.3 }}
-              transition={{ duration: 0.4 }}
-              className='text-sm uppercase tracking-wide text-primary/70'
-            >
+            <p className='text-sm uppercase tracking-wide text-brand/80'>
               {about?.intro}
-            </motion.p>
+            </p>
           </CardHeader>
 
           <CardContent className='space-y-5'>
-            <motion.p
-              initial={{ opacity: 0, y: 10 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: false, amount: 0.3 }}
-              transition={{ delay: 0.15, duration: 0.5 }}
-              className='whitespace-pre-line text-base leading-relaxed text-muted-foreground'
-            >
+            <p className='whitespace-pre-line text-base leading-relaxed text-muted-foreground'>
               {about?.content}
-            </motion.p>
+            </p>
           </CardContent>
         </Card>
       </motion.div>
@@ -102,43 +78,33 @@ export function AboutMe() {
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: false, amount: 0.25 }}
+        viewport={{ once: true, amount: 0.25 }}
         transition={{ duration: 0.6, delay: 0.1 }}
         className='flex h-full flex-col'
         style={
-          contentHeight && typeof window !== 'undefined' && window.innerWidth >= 768
+          contentHeight &&
+          typeof window !== 'undefined' &&
+          window.innerWidth >= 768
             ? { minHeight: `${contentHeight}px` }
             : undefined
         }
       >
         <Card className='flex h-full flex-col rounded-2xl border border-border/60 bg-card/70 shadow-lg backdrop-blur-md transition hover:shadow-xl'>
           <CardHeader className='space-y-3'>
-            <motion.div
-              initial={{ opacity: 0, y: 10 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: false, amount: 0.3 }}
-              transition={{ duration: 0.4 }}
-              className='flex items-center gap-2'
-            >
+            <div className='flex items-center gap-2'>
               <span className='relative flex h-3 w-3'>
                 <span className='absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75'></span>
                 <span className='relative inline-flex h-3 w-3 rounded-full bg-green-500'></span>
               </span>
-              <p className='text-sm uppercase tracking-wide text-primary/70'>
+              <p className='text-sm uppercase tracking-wide text-brand/80'>
                 {status?.title}
               </p>
-            </motion.div>
+            </div>
           </CardHeader>
 
           <CardContent className='flex flex-1 flex-col space-y-5'>
             {/* Availability status */}
-            <motion.div
-              initial={{ opacity: 0, y: 10 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: false, amount: 0.3 }}
-              transition={{ delay: 0.15, duration: 0.5 }}
-              className='space-y-4'
-            >
+            <div className='space-y-4'>
               <div className='flex flex-wrap items-center gap-3'>
                 <span className='inline-flex items-center gap-1.5 rounded-full border border-green-500/30 bg-green-500/10 px-3 py-1 text-sm font-medium text-green-600 dark:text-green-400'>
                   <Briefcase className='h-3.5 w-3.5' />
@@ -155,7 +121,7 @@ export function AboutMe() {
 
               {/* Regions */}
               <div className='flex items-start gap-2 text-sm text-muted-foreground'>
-                <MapPin className='mt-0.5 h-4 w-4 flex-shrink-0 text-primary/60' />
+                <MapPin className='mt-0.5 h-4 w-4 flex-shrink-0 text-brand/60' />
                 <div>
                   <p className='font-medium text-foreground/80'>
                     {status?.regions}
@@ -169,35 +135,23 @@ export function AboutMe() {
               <p className='text-sm italic text-muted-foreground/80'>
                 {status?.lookingFor}
               </p>
-            </motion.div>
+            </div>
 
             {/* Social links */}
-            <motion.div
-              initial={{ opacity: 0, y: 10 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: false, amount: 0.3 }}
-              transition={{ delay: 0.25, duration: 0.5 }}
-              className='mt-auto flex flex-wrap gap-3 pt-4'
-            >
-              {socialLinks.map((link, index) => (
-                <motion.a
+            <div className='mt-auto flex flex-wrap gap-3 pt-4'>
+              {socialLinks.map((link) => (
+                <a
                   key={link.name}
                   href={link.url}
                   target='_blank'
                   rel='noopener noreferrer'
-                  initial={{ opacity: 0, scale: 0.9 }}
-                  whileInView={{ opacity: 1, scale: 1 }}
-                  viewport={{ once: false, amount: 0.3 }}
-                  transition={{ delay: 0.3 + index * 0.1, duration: 0.4 }}
-                  whileHover={{ scale: 1.02 }}
-                  whileTap={{ scale: 0.98 }}
                   className={`group flex flex-1 items-center justify-center gap-2 rounded-xl border border-border/60 bg-background/50 px-4 py-3 text-sm font-medium text-muted-foreground backdrop-blur-sm transition-all duration-200 ${link.color} ${link.bgHover} hover:text-foreground`}
                 >
                   <link.icon className='h-5 w-5 transition-transform duration-200 group-hover:scale-110' />
                   <span>{link.name}</span>
-                </motion.a>
+                </a>
               ))}
-            </motion.div>
+            </div>
           </CardContent>
         </Card>
       </motion.div>

--- a/src/components/service/experience.tsx
+++ b/src/components/service/experience.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { useTranslations, useLocale } from 'next-intl';
-import { client } from '@/sanity/lib/client';
-import { allExperiencesQuery } from '@/sanity/queries/experiences';
 import Image from 'next/image';
 import TechIcon from '@/components/service/common/tech-icon';
 import {
@@ -16,18 +14,14 @@ import {
 import type { Experience } from '@/data/types/experience';
 import { motion } from 'framer-motion';
 
-export function Experience() {
+export function Experience({
+  experiences,
+}: {
+  experiences: Experience[];
+}) {
   const t = useTranslations();
   const locale = useLocale() as 'fr' | 'en' | 'ar' | 'kr';
-  const [experiences, setExperiences] = useState<Experience[]>([]);
   const [failedLogos, setFailedLogos] = useState(false);
-
-  useEffect(() => {
-    client
-      .fetch(allExperiencesQuery)
-      .then(setExperiences)
-      .catch((err) => console.error('❌ Failed to fetch experiences:', err));
-  }, []);
 
   if (!experiences.length)
     return (

--- a/src/components/service/hero.tsx
+++ b/src/components/service/hero.tsx
@@ -1,29 +1,16 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
-import { Skeleton } from '@/components/ui/skeleton';
-import { useLocale, useTranslations } from 'next-intl';
+import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { motion, useReducedMotion } from 'framer-motion';
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
 import { ArrowDown, ArrowRight } from 'lucide-react';
-import type { Hero } from '@/data/types/info';
-import { client } from '@/sanity/lib/client';
-import { heroQuery } from '@/sanity/queries/info';
+import type { Hero as HeroType } from '@/data/types/info';
 
-export function Hero() {
+export function Hero({ hero }: { hero: HeroType | null }) {
   const t = useTranslations();
-  const locale = useLocale();
   const reduceMotion = useReducedMotion();
-  const [hero, setHero] = useState<Hero | null>(null);
-
-  useEffect(() => {
-    client
-      .fetch(heroQuery, { locale })
-      .then(setHero)
-      .catch((err) => console.error('Failed to fetch Hero:', err));
-  }, [locale]);
 
   const fadeUp = {
     initial: { opacity: 0, y: reduceMotion ? 0 : 16 },
@@ -47,11 +34,7 @@ export function Hero() {
       </div>
 
       <div className='flex max-w-3xl flex-col items-center text-center'>
-        <motion.div
-          {...fadeUp}
-          transition={{ duration: 0.5 }}
-          className='relative'
-        >
+        <motion.div {...fadeUp} transition={{ duration: 0.5 }} className='relative'>
           <div className='absolute -inset-1.5 rounded-full bg-brand/20 blur-md' />
           <Image
             src={hero?.profileImage?.url ?? '/images/ramzi.jpg'}
@@ -66,31 +49,17 @@ export function Hero() {
         <motion.h1
           {...fadeUp}
           transition={{ duration: 0.5, delay: 0.08 }}
-          className='mt-8 min-h-[2.75rem] text-balance text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl'
+          className='mt-8 text-balance text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl'
         >
-          {hero ? (
-            hero.title
-          ) : (
-            <span className='mx-auto flex max-w-md flex-col gap-3'>
-              <Skeleton className='h-10 w-full' />
-              <Skeleton className='mx-auto h-10 w-2/3' />
-            </span>
-          )}
+          {hero?.title}
         </motion.h1>
 
         <motion.p
           {...fadeUp}
           transition={{ duration: 0.5, delay: 0.16 }}
-          className='mt-5 min-h-[3.5rem] max-w-2xl text-pretty text-base text-muted-foreground sm:text-lg'
+          className='mt-5 max-w-2xl text-pretty text-base text-muted-foreground sm:text-lg'
         >
-          {hero ? (
-            hero.subtitle
-          ) : (
-            <span className='mx-auto flex max-w-xl flex-col gap-2'>
-              <Skeleton className='h-5 w-full' />
-              <Skeleton className='mx-auto h-5 w-4/5' />
-            </span>
-          )}
+          {hero?.subtitle}
         </motion.p>
 
         <motion.div

--- a/src/components/service/language.tsx
+++ b/src/components/service/language.tsx
@@ -1,10 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { useTranslations } from 'next-intl';
-import { client } from '@/sanity/lib/client';
-import { allLanguagesQuery } from '@/sanity/queries/languages';
 
 const LEVEL_COLORS = [
   'bg-green-300',
@@ -13,26 +10,18 @@ const LEVEL_COLORS = [
   'bg-green-900',
 ];
 
-interface Language {
+export interface Language {
   _id: string;
   key: string;
   level: number;
 }
 
-export function Language() {
+export function Language({ languages }: { languages: Language[] }) {
   const t = useTranslations();
-  const [languages, setLanguages] = useState<Language[]>([]);
-
-  useEffect(() => {
-    client
-      .fetch(allLanguagesQuery)
-      .then((res) => setLanguages(res))
-      .catch((err) => console.error('❌ Failed to fetch languages:', err));
-  }, []);
 
   return (
     <div className='space-y-4'>
-      <Card className='border-2 p-4'>
+      <Card className='p-4'>
         <CardContent className='space-y-3'>
           {languages.length > 0 ? (
             languages.map((lang) => (
@@ -45,7 +34,9 @@ export function Language() {
                   {[1, 2, 3, 4].map((i) => (
                     <div
                       key={i}
-                      className={`h-3 flex-1 rounded-full ${i <= lang.level ? LEVEL_COLORS[i - 1] : 'bg-gray-300'}`}
+                      className={`h-3 flex-1 rounded-full ${
+                        i <= lang.level ? LEVEL_COLORS[i - 1] : 'bg-muted'
+                      }`}
                     />
                   ))}
                 </div>

--- a/src/components/service/motivation.tsx
+++ b/src/components/service/motivation.tsx
@@ -1,25 +1,17 @@
 'use client';
 
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
-import { useEffect, useState } from 'react';
-import { useLocale, useTranslations } from 'next-intl';
-import { client } from '@/sanity/lib/client';
-import { motivationQuery } from '@/sanity/queries/info';
-import type { Motivation } from '@/data/types/info';
+import { useTranslations } from 'next-intl';
+import type { Motivation as MotivationType } from '@/data/types/info';
 import Image from 'next/image';
 import { motion } from 'framer-motion';
 
-export function Motivation() {
+export function Motivation({
+  motivation,
+}: {
+  motivation: MotivationType | null;
+}) {
   const t = useTranslations();
-  const locale = useLocale();
-  const [motivation, setMotivation] = useState<Motivation | null>(null);
-
-  useEffect(() => {
-    client
-      .fetch(motivationQuery, { locale })
-      .then(setMotivation)
-      .catch((err) => console.error('❌ Failed to fetch Motivation:', err));
-  }, [locale]);
 
   return (
     <div className='grid grid-cols-1 items-center gap-12 md:grid-cols-2'>
@@ -60,25 +52,15 @@ export function Motivation() {
       >
         <Card className='rounded-2xl border border-border/60 bg-card/70 shadow-lg backdrop-blur-md transition hover:shadow-xl'>
           <CardHeader className='space-y-3'>
-            <motion.p
-              initial={{ opacity: 0, y: 10 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.4 }}
-              className='text-sm font-medium uppercase tracking-wider text-primary/80'
-            >
+            <p className='text-sm font-medium uppercase tracking-wider text-brand/80'>
               {motivation?.intro}
-            </motion.p>
+            </p>
           </CardHeader>
 
           <CardContent>
-            <motion.blockquote
-              initial={{ opacity: 0, y: 10 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.2, duration: 0.6 }}
-              className='border-l-4 border-primary/30 pl-4 text-base italic leading-relaxed text-muted-foreground'
-            >
+            <blockquote className='border-l-4 border-brand/30 pl-4 text-base italic leading-relaxed text-muted-foreground'>
               {motivation?.content}
-            </motion.blockquote>
+            </blockquote>
           </CardContent>
         </Card>
       </motion.div>

--- a/src/components/service/project-detail.tsx
+++ b/src/components/service/project-detail.tsx
@@ -20,8 +20,6 @@ import { useLocale, useTranslations } from 'next-intl';
 import { useRouter } from '@/i18n/navigation';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { client } from '@/sanity/lib/client';
-import { allProjectsQuery } from '@/sanity/queries/projects';
 import type { Project, ProjectStatus } from '@/data/types/project';
 import TechIcon from '@/components/service/common/tech-icon';
 
@@ -34,13 +32,18 @@ const statusIcon: Record<ProjectStatus, JSX.Element> = {
 
 const repoKeys = ['repo', 'repoFrontend', 'repoBackend', 'repoMobile'];
 
-export function ProjectDetail({ project }: { project: Project }) {
+export function ProjectDetail({
+  project,
+  siblings,
+}: {
+  project: Project;
+  siblings: Project[];
+}) {
   const t = useTranslations();
   const locale = useLocale();
   const router = useRouter();
   const reduceMotion = useReducedMotion();
 
-  const [projects, setProjects] = useState<Project[]>([]);
   const [lightbox, setLightbox] = useState<number | null>(null);
 
   const localized = project.translations?.[locale] ||
@@ -55,21 +58,14 @@ export function ProjectDetail({ project }: { project: Project }) {
     : [];
 
   useEffect(() => {
-    client
-      .fetch(allProjectsQuery)
-      .then((res: Project[]) => setProjects(res ?? []))
-      .catch((err) => console.error('Failed to fetch projects:', err));
-  }, []);
-
-  useEffect(() => {
     window.scrollTo({ top: 0 });
   }, [project._id]);
 
-  const currentIndex = projects.findIndex((p) => p._id === project._id);
-  const prevProject = currentIndex > 0 ? projects[currentIndex - 1] : null;
+  const currentIndex = siblings.findIndex((p) => p._id === project._id);
+  const prevProject = currentIndex > 0 ? siblings[currentIndex - 1] : null;
   const nextProject =
-    currentIndex >= 0 && currentIndex < projects.length - 1
-      ? projects[currentIndex + 1]
+    currentIndex >= 0 && currentIndex < siblings.length - 1
+      ? siblings[currentIndex + 1]
       : null;
 
   const titleOf = (p: Project) =>

--- a/src/components/service/project.tsx
+++ b/src/components/service/project.tsx
@@ -1,15 +1,12 @@
 'use client';
 
-import { JSX, useEffect, useState } from 'react';
+import { JSX } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 import { motion, useReducedMotion } from 'framer-motion';
 import Image from 'next/image';
 import { ArrowRight, CheckCircle, Clock, PauseCircle, Rocket } from 'lucide-react';
 import { Link } from '@/i18n/navigation';
-import { client } from '@/sanity/lib/client';
-import { allProjectsQuery } from '@/sanity/queries/projects';
 import { Badge } from '@/components/ui/badge';
-import { Skeleton } from '@/components/ui/skeleton';
 import TechIcon from '@/components/service/common/tech-icon';
 import type { Project as ProjectType, ProjectStatus } from '@/data/types/project';
 
@@ -130,37 +127,8 @@ function ProjectCard({
   );
 }
 
-function ProjectCardSkeleton() {
-  return (
-    <div className='flex flex-col overflow-hidden rounded-xl border border-border/70 bg-card'>
-      <Skeleton className='aspect-[16/10] w-full rounded-none' />
-      <div className='flex flex-col gap-3 p-5'>
-        <Skeleton className='h-3 w-20' />
-        <Skeleton className='h-5 w-3/4' />
-        <Skeleton className='h-16 w-full' />
-        <div className='flex gap-1.5'>
-          <Skeleton className='h-6 w-16' />
-          <Skeleton className='h-6 w-16' />
-          <Skeleton className='h-6 w-16' />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-export function Project() {
+export function Project({ projects }: { projects: ProjectType[] }) {
   const t = useTranslations();
-  const [projects, setProjects] = useState<ProjectType[] | null>(null);
-
-  useEffect(() => {
-    client
-      .fetch(allProjectsQuery)
-      .then((res: ProjectType[]) => setProjects(res ?? []))
-      .catch((err) => {
-        console.error('Failed to fetch projects:', err);
-        setProjects([]);
-      });
-  }, []);
 
   return (
     <div className='space-y-8'>
@@ -168,13 +136,7 @@ export function Project() {
         {t('common.projects.intro')}
       </p>
 
-      {projects === null ? (
-        <div className='grid gap-6 sm:grid-cols-2'>
-          {Array.from({ length: 4 }).map((_, i) => (
-            <ProjectCardSkeleton key={i} />
-          ))}
-        </div>
-      ) : projects.length === 0 ? (
+      {projects.length === 0 ? (
         <p className='text-center text-muted-foreground'>
           {t('common.projects.empty')}
         </p>

--- a/src/components/service/skill.tsx
+++ b/src/components/service/skill.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Card, CardContent } from '@/components/ui/card';
@@ -11,20 +11,13 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { useTranslations } from 'next-intl';
-import { client } from '@/sanity/lib/client';
-import { allSkillsQuery } from '@/sanity/queries/skills';
 import TechIcon from '@/components/service/common/tech-icon';
 import { motion } from 'framer-motion';
 import type { Skill } from '@/data/types/skill';
 
-export function Skill() {
+export function Skill({ skills }: { skills: Skill[] }) {
   const t = useTranslations();
-  const [skills, setSkills] = useState<Skill[]>([]);
   const [failedLogos, setFailedLogos] = useState(false);
-
-  useEffect(() => {
-    client.fetch(allSkillsQuery).then(setSkills).catch(console.error);
-  }, []);
 
   const handleImgError = () => setFailedLogos(true);
 


### PR DESCRIPTION
Closes #38 — sixième chantier de la V2.

## Ce qui change
- `page.tsx` est désormais un **Server Component** : il récupère les données de toutes les sections en parallèle (`Promise.all`) et les passe en props.
- Les composants de section (Hero, About, Motivation, Experience, Skills, Projects, Languages) ne chargent plus leurs données via `useEffect` — ils restent `'use client'` pour les animations mais reçoivent leurs données en props.
- Conséquence : **le contenu est présent dans le HTML rendu côté serveur** (gain SEO et LCP), et la cascade de requêtes client est supprimée.
- La logique de scroll-restore est isolée dans `ScrollRestoration` (petit composant client).
- Page de détail projet : la navigation précédent/suivant est alimentée côté serveur — plus aucune requête de données côté client sur cette route.
- Chaque échec de requête Sanity est isolé (`catch`) : une section vide n'empêche pas le rendu du reste.

## Correctif
- `suppressHydrationWarning` ajouté sur `<html>` : `next-themes` applique la classe de thème avant l'hydratation, cette différence attendue ne doit pas être signalée comme un écart.

## Vérification
- Build de production OK, type-check OK.
- First Load JS de l'accueil : **289 kB → 243 kB** ; page de détail : **238 kB → 183 kB**.
- Les 3 locales répondent `200` ; le HTML serveur contient les 7 sections, les titres `h1`/`h2`, les métadonnées et le JSON-LD.
- Limite : l'outil de capture d'écran navigateur n'a pas répondu pendant cette session — vérification faite via HTTP, logs serveur (propres) et build. Revue visuelle finale à faire sur la preview Vercel avec le contenu Sanity réel.

## Note
La page d'accueil est en `force-dynamic` : rendu serveur à chaque requête, données toujours fraîches. Le passage en ISR (cache + revalidation) pourra être un réglage ultérieur si besoin.