### PR TITLE
V2 — Identité visuelle & logo personnel

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,4 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" rx="14" fill="#4F46E5" />
+  <text x="32" y="45" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="40" font-weight="700" fill="#FFFFFF">R</text>
+</svg>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -71,7 +71,7 @@ export async function generateMetadata({
       follow: true,
       googleBot: { index: true, follow: true },
     },
-    icons: { icon: '/images/logo.jpg' },
+    icons: { icon: { url: '/logo.svg', type: 'image/svg+xml' } },
   };
 }
 
@@ -126,8 +126,8 @@ export default async function LocaleLayout({ children, params }: Props) {
           >
             <ActiveSectionProvider>
               <Header
-                logoSrc={'/images/logo.jpg'}
-                logoAlt={'Logo'}
+                logoSrc={'/logo.svg'}
+                logoAlt={'Ramzi Benmansour'}
                 locale={locale as Locale}
               />
               <div className='flex min-h-screen flex-col'>{children}</div>

--- a/src/app/[locale]/opengraph-image.tsx
+++ b/src/app/[locale]/opengraph-image.tsx
@@ -33,13 +33,20 @@ export default function OpengraphImage() {
         >
           <div
             style={{
-              width: 48,
-              height: 6,
-              background: '#6366f1',
-              borderRadius: 4,
               display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 66,
+              height: 66,
+              borderRadius: 16,
+              background: '#4F46E5',
+              color: '#ffffff',
+              fontSize: 38,
+              fontWeight: 700,
             }}
-          />
+          >
+            R
+          </div>
           PORTFOLIO
         </div>
 


### PR DESCRIPTION
Closes #42 — chantier d'itération finale.

## Ce qui change
- Nouveau **monogramme** SVG : une tuile arrondie à l'accent indigo du design system portant l'initiale. Minimal, reconnaissable, déclinable.
- Remplace l'image placeholder dans le header et le favicon (`image/svg+xml`).
- L'image Open Graph reprend le monogramme à la place de la barre d'accent.

## Vérification
- Build OK, `/logo.svg` servi en `image/svg+xml`, référencé dans le header.

## Note
Outil de capture navigateur indisponible cette session — vérif via build + HTTP. Rendu visuel final à confirmer sur la preview Vercel.