### PR TITLE
V2 — Scroll & navigation

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -9,6 +9,8 @@ import './globals.css';
 import { Toaster } from 'sonner';
 import { Footer } from '@/components/layout/footer';
 import { ActiveSectionProvider } from '@/hooks/use-active-section';
+import { ScrollProgress } from '@/components/layout/scroll-progress';
+import { BackToTop } from '@/components/layout/back-to-top';
 import { Inter } from 'next/font/google';
 import type { Metadata } from 'next';
 import { getBaseUrl, ogLocale, seoContent, siteName } from '@/lib/seo';
@@ -125,6 +127,7 @@ export default async function LocaleLayout({ children, params }: Props) {
             disableTransitionOnChange
           >
             <ActiveSectionProvider>
+              <ScrollProgress />
               <Header
                 logoSrc={'/logo.svg'}
                 logoAlt={'Ramzi Benmansour'}
@@ -133,6 +136,7 @@ export default async function LocaleLayout({ children, params }: Props) {
               <div className='flex min-h-screen flex-col'>{children}</div>
               <Toaster richColors position='top-center' />
               <Footer />
+              <BackToTop />
             </ActiveSectionProvider>
           </ThemeProvider>
         </NextIntlClientProvider>

--- a/src/components/layout/back-to-top.tsx
+++ b/src/components/layout/back-to-top.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { ArrowUp } from 'lucide-react';
+
+export function BackToTop() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 700);
+
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.button
+          type='button'
+          aria-label='Back to top'
+          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+          initial={{ opacity: 0, scale: 0.8 }}
+          animate={{ opacity: 1, scale: 1 }}
+          exit={{ opacity: 0, scale: 0.8 }}
+          transition={{ duration: 0.2 }}
+          className='fixed bottom-6 right-6 z-50 flex size-11 items-center justify-center rounded-full border border-border/60 bg-card/80 text-foreground shadow-lg backdrop-blur-md transition-colors hover:border-brand/40 hover:text-brand'
+        >
+          <ArrowUp className='size-5' />
+        </motion.button>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/layout/scroll-progress.tsx
+++ b/src/components/layout/scroll-progress.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { motion, useScroll, useSpring } from 'framer-motion';
+
+export function ScrollProgress() {
+  const { scrollYProgress } = useScroll();
+  const scaleX = useSpring(scrollYProgress, {
+    stiffness: 120,
+    damping: 30,
+    mass: 0.3,
+  });
+
+  return (
+    <motion.div
+      aria-hidden
+      style={{ scaleX }}
+      className='fixed inset-x-0 top-0 z-[60] h-0.5 origin-left bg-brand'
+    />
+  );
+}


### PR DESCRIPTION
Closes #46 — chantier d'itération finale.

## Ce qui change
- **Barre de progression de scroll** : fine, à l'accent indigo, en haut du viewport, lissée par ressort.
- **Bouton retour-en-haut** : apparaît après le premier écran, scroll fluide vers le haut.
- Implémentation par `transform` (GPU), composants isolés.

## Choix
Le scroll-snap forcé a été écarté volontairement : sur des sections longues (projets, expériences) il nuit à la fluidité et tombe dans le gadget.

## Vérification
Build OK, type-check OK.