### PR TITLE
Projets — contextes Sanity remplis & tirets retirés

### DIFF
--- a/src/components/service/project-detail.tsx
+++ b/src/components/service/project-detail.tsx
@@ -194,7 +194,7 @@ export function ProjectDetail({
               ))}
             </div>
           ) : (
-            <p className='text-sm text-muted-foreground'>—</p>
+            <p className='text-sm text-muted-foreground'>-</p>
           )}
         </section>
 


### PR DESCRIPTION
## Contenu Sanity (exécuté via l'API d'écriture)
- **Champs case-study remplis** pour les **8 projets** dans les **4 locales** : `context`, `noteLabel`, `noteBody` (96 champs). Contenu rédigé à partir des données réelles de chaque projet (description, stack, statut, liens), sobre, sans tiret cadratin ni tournure générique.
- **Tirets normalisés** dans le contenu Sanity existant : 16 occurrences de `—`/`–` remplacées par `-` (périodes d'expériences, description Espace Privatif).

## Code
- `project-detail.tsx` : le marqueur d'état vide « stack » utilisait un tiret cadratin, remplacé par un trait d'union.

## Vérification
- Inspection Sanity : les 8 projets ont leurs champs case-study complets sur les 4 locales ; aucun `—`/`–` restant dans le contenu.
- Build production OK, type-check OK.

## Note
Le contenu rempli est dérivé fidèlement des données projet existantes — à relire/affiner dans Sanity Studio si besoin (notamment les sections d'analyse).