### PR TITLE
Production — contextes projets & normalisation des tirets

### DIFF
--- a/src/components/service/project-detail.tsx
+++ b/src/components/service/project-detail.tsx
@@ -194,7 +194,7 @@ export function ProjectDetail({
               ))}
             </div>
           ) : (
-            <p className='text-sm text-muted-foreground'>—</p>
+            <p className='text-sm text-muted-foreground'>-</p>
           )}
         </section>
 


### PR DESCRIPTION
Promotion du correctif : marqueur stack-vide sans tiret cadratin. (Les champs case-study des projets et la normalisation des tirets ont été appliqués directement dans Sanity et sont déjà actifs en production de données.)