### PR TITLE
Restaurer le logo image d'origine

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,4 +1,0 @@
-<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="64" height="64" rx="14" fill="#4F46E5" />
-  <text x="32" y="45" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="40" font-weight="700" fill="#FFFFFF">R</text>
-</svg>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -74,7 +74,7 @@ export async function generateMetadata({
       follow: true,
       googleBot: { index: true, follow: true },
     },
-    icons: { icon: { url: '/logo.svg', type: 'image/svg+xml' } },
+    icons: { icon: '/images/logo.jpg' },
   };
 }
 
@@ -128,7 +128,7 @@ export default async function LocaleLayout({ children, params }: Props) {
             <ActiveSectionProvider>
               <ScrollProgress />
               <Header
-                logoSrc={'/logo.svg'}
+                logoSrc={'/images/logo.jpg'}
                 logoAlt={'Ramzi Benmansour'}
                 locale={locale as Locale}
               />

--- a/src/app/[locale]/opengraph-image.tsx
+++ b/src/app/[locale]/opengraph-image.tsx
@@ -33,20 +33,13 @@ export default function OpengraphImage() {
         >
           <div
             style={{
+              width: 48,
+              height: 6,
+              background: '#6366f1',
+              borderRadius: 4,
               display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: 66,
-              height: 66,
-              borderRadius: 16,
-              background: '#4F46E5',
-              color: '#ffffff',
-              fontSize: 38,
-              fontWeight: 700,
             }}
-          >
-            R
-          </div>
+          />
           PORTFOLIO
         </div>
 


### PR DESCRIPTION
Abandon du monogramme : le logo du header et le favicon réutilisent l'image d'origine (`/images/logo.jpg`), l'image OG revient à son bandeau d'accent. `public/logo.svg` supprimé.