### PR TITLE
fix: mobile rendering and menu navigation

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -70,7 +70,7 @@ export default async function HomePage({ params }: { params: Params }) {
     ]);
 
   return (
-    <main className='space-y-32'>
+    <main className='space-y-20 sm:space-y-24 md:space-y-32'>
       <ScrollRestoration />
 
       <Hero hero={hero} status={status} />

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import Image from 'next/image';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { useRouter, usePathname } from '@/i18n/navigation';
 import { Locale } from '@/i18n/routing';
@@ -15,7 +15,6 @@ import LanguageSelector from '@/components/layout/language-selector';
 import { ThemeToggle } from '@/components/layout/theme-toggle';
 import {
   Drawer,
-  DrawerClose,
   DrawerContent,
   DrawerHeader,
   DrawerTitle,
@@ -34,6 +33,7 @@ export function Header({ logoSrc, logoAlt = 'Logo', locale }: HeaderProps) {
   const pathname = usePathname();
   const { id: activeId } = useActiveSection();
   const [mobileOpen, setMobileOpen] = useState(false);
+  const pendingTargetRef = useRef<string | null>(null);
 
   const items = [
     { id: 'about', label: t('common.header.about') },
@@ -47,7 +47,7 @@ export function Header({ logoSrc, logoAlt = 'Logo', locale }: HeaderProps) {
 
   const isHome = !pathname.startsWith(`/project`);
 
-  const goToSection = (id: string) => {
+  const scrollToId = (id: string) => {
     if (isHome) {
       const el = document.getElementById(id);
 
@@ -62,10 +62,31 @@ export function Header({ logoSrc, logoAlt = 'Logo', locale }: HeaderProps) {
     }
   };
 
+  // Desktop nav: scroll right away.
   const handleNavClick = (e: React.MouseEvent, id: string) => {
     e.preventDefault();
-    goToSection(id);
+    scrollToId(id);
   };
+
+  // Mobile nav: store the target, close the drawer, then scroll once the
+  // drawer is fully closed (vaul releases the body scroll lock on close).
+  const handleMobileNavClick = (e: React.MouseEvent, id: string) => {
+    e.preventDefault();
+    pendingTargetRef.current = id;
+    setMobileOpen(false);
+  };
+
+  useEffect(() => {
+    if (mobileOpen) return;
+    const id = pendingTargetRef.current;
+
+    if (!id) return;
+    pendingTargetRef.current = null;
+    // vaul close animation lands within ~250ms; give it a small margin so the
+    // body scroll lock is fully released before we trigger smooth scroll.
+    const timer = window.setTimeout(() => scrollToId(id), 320);
+    return () => window.clearTimeout(timer);
+  }, [mobileOpen]);
 
   return (
     <header className='sticky top-0 z-50 w-full border-b border-border/50 bg-background/80 backdrop-blur-md transition-all'>
@@ -136,23 +157,22 @@ export function Header({ logoSrc, logoAlt = 'Logo', locale }: HeaderProps) {
                   const isActive = activeId === item.id;
 
                   return (
-                    <DrawerClose asChild key={item.id}>
-                      <Link
-                        href={`/${locale}#${item.id}`}
-                        onClick={(e) => handleNavClick(e, item.id)}
-                        className={clsx(
-                          'flex items-center justify-between rounded-lg px-4 py-3.5 text-base font-medium transition-colors',
-                          isActive
-                            ? 'bg-brand/10 text-brand'
-                            : 'text-foreground/80 hover:bg-accent hover:text-foreground'
-                        )}
-                      >
-                        {item.label}
-                        {isActive && (
-                          <span className='size-2 rounded-full bg-brand' />
-                        )}
-                      </Link>
-                    </DrawerClose>
+                    <Link
+                      key={item.id}
+                      href={`/${locale}#${item.id}`}
+                      onClick={(e) => handleMobileNavClick(e, item.id)}
+                      className={clsx(
+                        'flex items-center justify-between rounded-lg px-4 py-3.5 text-base font-medium transition-colors',
+                        isActive
+                          ? 'bg-brand/10 text-brand'
+                          : 'text-foreground/80 hover:bg-accent hover:text-foreground'
+                      )}
+                    >
+                      {item.label}
+                      {isActive && (
+                        <span className='size-2 rounded-full bg-brand' />
+                      )}
+                    </Link>
                   );
                 })}
               </nav>

--- a/src/components/layout/section-wrapper.tsx
+++ b/src/components/layout/section-wrapper.tsx
@@ -59,24 +59,22 @@ export default function SectionWrapper({
   }, [id, setId]);
 
   return (
-    <motion.section
-      id={id}
-      ref={ref}
-      className={className + ' scroll-mt-24'}
-      initial={{ opacity: 0, y: reduceMotion ? 0 : 24 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, amount: 0.15 }}
-      transition={{ duration: 0.55, ease: [0.22, 1, 0.36, 1] }}
-    >
-      <div className='mx-auto max-w-7xl px-6'>
-        <div className='mb-10 flex flex-col items-center gap-3 text-center'>
-          <h2 className='text-3xl font-bold tracking-tight md:text-4xl'>
+    <section id={id} ref={ref} className={className + ' scroll-mt-20 sm:scroll-mt-24'}>
+      <div className='mx-auto max-w-7xl px-4 sm:px-6'>
+        <motion.div
+          initial={{ opacity: 0, y: reduceMotion ? 0 : 16 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 'some' }}
+          transition={{ duration: 0.45, ease: [0.22, 1, 0.36, 1] }}
+          className='mb-6 flex flex-col items-center gap-3 text-center sm:mb-8 md:mb-10'
+        >
+          <h2 className='text-2xl font-bold tracking-tight sm:text-3xl md:text-4xl'>
             {t(titleKey)}
           </h2>
           <span className='h-1 w-10 rounded-full bg-brand/70' />
-        </div>
+        </motion.div>
         <div>{children}</div>
       </div>
-    </motion.section>
+    </section>
   );
 }

--- a/src/components/service/about-me.tsx
+++ b/src/components/service/about-me.tsx
@@ -55,7 +55,7 @@ export function AboutMe({
         ref={textRef}
         initial={{ opacity: 0, y: 20 }}
         whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: true, amount: 0.25 }}
+        viewport={{ once: true, amount: 'some' }}
         transition={{ duration: 0.6 }}
         className='h-full'
       >
@@ -78,7 +78,7 @@ export function AboutMe({
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: true, amount: 0.25 }}
+        viewport={{ once: true, amount: 'some' }}
         transition={{ duration: 0.6, delay: 0.1 }}
         className='flex h-full flex-col'
         style={

--- a/src/components/service/contact-me.tsx
+++ b/src/components/service/contact-me.tsx
@@ -77,7 +77,7 @@ export function ContactMe() {
     <motion.div
       initial={{ opacity: 0, y: 25 }}
       whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, amount: 0.2 }}
+      viewport={{ once: true, amount: 'some' }}
       transition={{ duration: 0.6 }}
     >
         <Card className='rounded-2xl border border-border/60 bg-card/80 shadow-lg backdrop-blur-md'>

--- a/src/components/service/experience.tsx
+++ b/src/components/service/experience.tsx
@@ -48,7 +48,7 @@ export function Experience({
               key={exp._id}
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true, amount: 0.2 }}
+              viewport={{ once: true, amount: 'some' }}
               transition={{ delay: Math.min(idx * 0.08, 0.32), duration: 0.5 }}
             >
               <Card className='group h-full rounded-2xl border border-border/60 bg-card/70 shadow-lg backdrop-blur-sm transition hover:-translate-y-1 hover:shadow-xl'>

--- a/src/components/service/hero.tsx
+++ b/src/components/service/hero.tsx
@@ -31,7 +31,7 @@ export function Hero({
   return (
     <section
       id='hero'
-      className='relative flex min-h-[calc(100svh-var(--header-h,4rem))] flex-col items-center justify-center overflow-hidden px-4 py-24 sm:py-32'
+      className='relative flex min-h-[calc(100svh-var(--header-h,4rem))] flex-col items-center justify-center overflow-hidden px-4 py-16 sm:py-24 md:py-32'
     >
       {/* Ambient background */}
       <div className='pointer-events-none absolute inset-0 -z-10'>

--- a/src/components/service/motivation.tsx
+++ b/src/components/service/motivation.tsx
@@ -19,7 +19,7 @@ export function Motivation({
         initial={{ opacity: 0, scale: 0.95 }}
         whileInView={{ opacity: 1, scale: 1 }}
         transition={{ duration: 0.8, ease: 'easeOut' }}
-        viewport={{ once: true, amount: 0.3 }}
+        viewport={{ once: true, amount: 'some' }}
         className='flex justify-center'
       >
         {motivation?.image?.url ? (
@@ -47,7 +47,7 @@ export function Motivation({
       <motion.div
         initial={{ opacity: 0, y: 30 }}
         whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: true, amount: 0.3 }}
+        viewport={{ once: true, amount: 'some' }}
         transition={{ duration: 0.7, ease: 'easeOut' }}
       >
         <Card className='rounded-2xl border border-border/60 bg-card/70 shadow-lg backdrop-blur-md transition hover:shadow-xl'>

--- a/src/components/service/project.tsx
+++ b/src/components/service/project.tsx
@@ -43,12 +43,12 @@ function ProjectCard({
 
   return (
     <motion.div
-      initial={{ opacity: 0, y: reduceMotion ? 0 : 24 }}
+      initial={{ opacity: 0, y: reduceMotion ? 0 : 18 }}
       whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, amount: 0.2 }}
+      viewport={{ once: true, amount: 'some' }}
       transition={{
-        duration: 0.5,
-        delay: Math.min(index * 0.07, 0.28),
+        duration: 0.45,
+        delay: Math.min(index * 0.06, 0.24),
         ease: [0.22, 1, 0.36, 1],
       }}
     >


### PR DESCRIPTION
## Changes

- section opacity was gated by whileInView with amount 0.15 on tall sections, which left the projects section blank on mobile until you had scrolled past most of it. The wrapper no longer fades the whole section, only the heading.
- per-card amount values were too high for full-width mobile cards; switched to amount 'some' so cards animate in as soon as any part enters the viewport.
- mobile menu items used DrawerClose around a Link, so the smooth scroll fired while vaul still held the body scroll lock. The drawer now closes first, then the page scrolls once the lock is released.
- tightened section spacing and hero padding on mobile so more content fits without feeling cramped.

## Test plan

- [x] build
- [x] typecheck
- [ ] vercel preview
- [ ] iPhone Safari + Chrome Android scroll through home
- [ ] tap each item in mobile menu, confirm the page navigates
- [ ] all 4 locales render projects correctly